### PR TITLE
fix(gcp): harden controller to match k8s controller patterns

### DIFF
--- a/internal/controller/gcp/compatibility_test.go
+++ b/internal/controller/gcp/compatibility_test.go
@@ -58,9 +58,8 @@ var _ = Describe("Backward Compatibility", func() {
 
 			result, err := reconciler.Reconcile(ctx, req)
 
-			// FetchHandler returns CriticalError when resource is not found.
-			// The controller wraps with client.IgnoreNotFound, which suppresses
-			// K8s NotFound errors — so the reconcile returns no error.
+			// FetchHandler returns nil on NotFound (controller-runtime would otherwise log a
+			// spurious "Reconciler error"). So the reconcile returns no error and no requeue.
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 		})
@@ -185,17 +184,19 @@ var _ = Describe("Backward Compatibility", func() {
 				},
 			}
 
-			// First reconciliation adds finalizer; auth may or may not fail depending on env
+			// First reconciliation adds finalizer; auth may or may not fail depending on env.
+			// Either way, FinalizerHandler runs before AuthHandler in the chain so the finalizer
+			// must be persisted on the server regardless of what AuthHandler does next.
 			_, err := reconciler.Reconcile(ctx, req)
-			_ = err // error is environment-dependent (GCP credentials may or may not be available)
+			if err != nil {
+				Expect(service.IsCriticalError(err)).To(BeTrue())
+			}
 
-			// Verify finalizer was added before the auth handler failed
 			updatedScaler := &kubecloudscalerv1alpha3.Gcp{}
-			err = k8sClient.Get(ctx, types.NamespacedName{
+			Expect(k8sClient.Get(ctx, types.NamespacedName{
 				Name:      scaler.Name,
 				Namespace: scaler.Namespace,
-			}, updatedScaler)
-			Expect(err).ToNot(HaveOccurred())
+			}, updatedScaler)).To(Succeed())
 			Expect(updatedScaler.Finalizers).To(ContainElement("kubecloudscaler.cloud/finalizer"))
 		})
 	})

--- a/internal/controller/gcp/scaler_controller.go
+++ b/internal/controller/gcp/scaler_controller.go
@@ -107,12 +107,8 @@ func (r *ScalerReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	err := r.chain.Execute(reconCtx)
 	duration := time.Since(start).Seconds()
 
-	// Close GCP client connections to prevent resource leaks
-	if reconCtx.GCPClient != nil {
-		if closeErr := reconCtx.GCPClient.Close(); closeErr != nil {
-			logger.Warn().Err(closeErr).Msg("failed to close GCP client")
-		}
-	}
+	// Note: GCPClient is owned by the AuthHandler cache (keyed by secret + ResourceVersion).
+	// Do NOT close it here — the cache handles lifecycle, closing stale entries on rotation.
 
 	// Handle chain execution result with proper error classification
 	if err != nil {

--- a/internal/controller/gcp/scaler_controller_test.go
+++ b/internal/controller/gcp/scaler_controller_test.go
@@ -30,7 +30,6 @@ import (
 
 	"github.com/kubecloudscaler/kubecloudscaler/api/common"
 	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
-	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
 )
 
 var _ = Describe("Scaler Controller", func() {
@@ -122,13 +121,23 @@ var _ = Describe("Scaler Controller", func() {
 				},
 			}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
+			if err != nil && errors.IsNotFound(err) {
+				// Resource was deleted by the test itself; nothing to clean up.
+				return
+			}
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Cleanup the specific resource instance Scaler")
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
-		It("should handle reconciliation with proper error handling", func() {
-			By("Reconciling the created resource")
+
+		It("should gracefully handle a NotFound via the handler chain", func() {
+			By("Deleting the resource before reconciling")
+			existing := &kubecloudscalerv1alpha3.Gcp{}
+			Expect(k8sClient.Get(ctx, typeNamespacedName, existing)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, existing)).To(Succeed())
+
+			By("Reconciling the deleted resource")
 			controllerReconciler := &ScalerReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
@@ -139,11 +148,10 @@ var _ = Describe("Scaler Controller", func() {
 				NamespacedName: typeNamespacedName,
 			})
 
-			// GCP auth may or may not fail depending on credentials availability in the test environment.
-			if err != nil {
-				Expect(service.IsCriticalError(err)).To(BeTrue())
-				Expect(result.RequeueAfter).To(BeZero())
-			}
+			// FetchHandler must swallow NotFound without requeue or error, so controller-runtime
+			// does not log a spurious "Reconciler error".
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero())
 		})
 	})
 })

--- a/internal/controller/gcp/service/context.go
+++ b/internal/controller/gcp/service/context.go
@@ -68,6 +68,13 @@ type ReconciliationContext struct {
 	// Scaler is the GCP scaler resource being reconciled (populated by fetch handler)
 	Scaler *kubecloudscalerv1alpha3.Gcp
 
+	// ScalerOriginal is a DeepCopy of the Scaler captured immediately after fetch,
+	// before any handler mutation. Used as the base for client.MergeFrom patches so
+	// mutations on Scaler do not pollute the patch diff.
+	// Set by: FetchHandler
+	// Used by: FinalizerHandler, StatusHandler (patch base, future use)
+	ScalerOriginal *kubecloudscalerv1alpha3.Gcp
+
 	// Secret is the authentication secret for GCP access (populated by auth handler, nullable)
 	Secret *corev1.Secret
 

--- a/internal/controller/gcp/service/context.go
+++ b/internal/controller/gcp/service/context.go
@@ -68,13 +68,6 @@ type ReconciliationContext struct {
 	// Scaler is the GCP scaler resource being reconciled (populated by fetch handler)
 	Scaler *kubecloudscalerv1alpha3.Gcp
 
-	// ScalerOriginal is a DeepCopy of the Scaler captured immediately after fetch,
-	// before any handler mutation. Used as the base for client.MergeFrom patches so
-	// mutations on Scaler do not pollute the patch diff.
-	// Set by: FetchHandler
-	// Used by: FinalizerHandler, StatusHandler (patch base, future use)
-	ScalerOriginal *kubecloudscalerv1alpha3.Gcp
-
 	// Secret is the authentication secret for GCP access (populated by auth handler, nullable)
 	Secret *corev1.Secret
 

--- a/internal/controller/gcp/service/handlers/auth_cache.go
+++ b/internal/controller/gcp/service/handlers/auth_cache.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"sync"
+
+	gcpUtils "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils"
+)
+
+// cacheKey identifies a cached GCP ClientSet. The zero value {"", ""} denotes the
+// Application-Default-Credentials path (no secret). Namespace is included so that two
+// secrets with the same name in different namespaces never share a cached client — today
+// the operator resolves a single namespace, but this defends against a future refactor that
+// allows per-scaler secret namespaces.
+type cacheKey struct {
+	namespace string
+	name      string
+}
+
+// clientCloser is the seam the cache uses to release a stale ClientSet on rotation. In
+// production it delegates to *ClientSet.Close; tests inject a recording closer so that
+// the close-before-store invariant is observable.
+type clientCloser func(cs *gcpUtils.ClientSet) error
+
+// cachedGCPClient pairs a ClientSet with the Secret.ResourceVersion it was built from.
+// A rotation (RV change) invalidates the entry so revoked credentials cannot linger past
+// the next reconcile.
+type cachedGCPClient struct {
+	resourceVersion string
+	clientSet       *gcpUtils.ClientSet
+}
+
+// gcpClientCache is a goroutine-safe cache of GCP ClientSets keyed by (namespace, name) of
+// the auth secret. All operations serialise through a single mutex; GCP auth setup is
+// infrequent compared to the API calls downstream so per-key locking would be overkill.
+//
+// Concurrency caveat: Close is invoked synchronously when a stale entry is replaced. A
+// long-running reconcile that captured a pointer via Get and is still using it when the
+// rotation fires may observe a closed client. This is accepted: secret rotations are rare
+// and gRPC surfaces the failure as a retryable error — preferable to leaking connections.
+type gcpClientCache struct {
+	mu      sync.Mutex
+	entries map[cacheKey]*cachedGCPClient
+	close   clientCloser
+}
+
+func newGCPClientCache() *gcpClientCache {
+	return &gcpClientCache{
+		entries: make(map[cacheKey]*cachedGCPClient),
+		close:   func(cs *gcpUtils.ClientSet) error { return cs.Close() },
+	}
+}
+
+// GetOrBuild returns a cached ClientSet whose stored ResourceVersion equals rv, or calls
+// build to create one and stores it under key. On rotation (key present with a different
+// rv) the previously cached ClientSet is closed before the new one is stored. The close
+// error, if any, is returned alongside the new client so the caller can log it — the new
+// client is always stored regardless. Concurrent calls are serialised.
+func (c *gcpClientCache) GetOrBuild(
+	key cacheKey,
+	rv string,
+	build func() (*gcpUtils.ClientSet, error),
+) (*gcpUtils.ClientSet, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if entry, ok := c.entries[key]; ok && entry.resourceVersion == rv {
+		return entry.clientSet, nil
+	}
+
+	cs, err := build()
+	if err != nil {
+		return nil, err
+	}
+
+	var closeErr error
+	if prior, ok := c.entries[key]; ok {
+		closeErr = c.close(prior.clientSet)
+	}
+	c.entries[key] = &cachedGCPClient{resourceVersion: rv, clientSet: cs}
+	return cs, closeErr
+}

--- a/internal/controller/gcp/service/handlers/auth_handler.go
+++ b/internal/controller/gcp/service/handlers/auth_handler.go
@@ -17,22 +17,56 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"fmt"
+	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/kubecloudscaler/kubecloudscaler/internal/config"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
+	gcpUtils "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils"
 	gcpClient "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils/client"
 )
 
-// AuthHandler sets up GCP client with authentication.
+// cachedGCPClient holds a cached GCP client set together with the ResourceVersion of the
+// secret it was built from. When the secret is rotated (its ResourceVersion changes), the
+// cached entry is treated as stale and the client is rebuilt — otherwise revoked
+// credentials would remain usable until the controller restarts.
+type cachedGCPClient struct {
+	resourceVersion string
+	clientSet       *gcpUtils.ClientSet
+}
+
+// ClientFactory builds a GCP ClientSet from an optional auth secret.
+// Nil secret means use Application Default Credentials.
+type ClientFactory func(ctx context.Context, secret *corev1.Secret) (*gcpUtils.ClientSet, error)
+
+// defaultClientFactory delegates to the concrete gcpClient.GetClient factory.
+func defaultClientFactory(ctx context.Context, secret *corev1.Secret) (*gcpUtils.ClientSet, error) {
+	return gcpClient.GetClient(ctx, secret)
+}
+
+// AuthHandlerOption configures an AuthHandler at construction time.
+type AuthHandlerOption func(*AuthHandler)
+
+// WithClientFactory overrides the default client factory. Intended for tests.
+func WithClientFactory(factory ClientFactory) AuthHandlerOption {
+	return func(h *AuthHandler) {
+		if factory != nil {
+			h.clientFactory = factory
+		}
+	}
+}
+
+// AuthHandler sets up the GCP client with authentication.
 // This handler manages authentication secrets and initializes the GCP API client.
 //
 // Responsibilities:
 //   - Fetch authentication secret if specified
-//   - Initialize GCP client with credentials
+//   - Cache the GCP ClientSet keyed by secret name + ResourceVersion so a rotation invalidates
+//     stale credentials, and successive reconciliations reuse the same client
 //   - Populate GCPClient and Secret in context
 //
 // Error Handling:
@@ -40,26 +74,36 @@ import (
 //   - Client creation failure: Critical error (stops chain)
 type AuthHandler struct {
 	next              service.Handler
+	clientCache       sync.Map // map[string]*cachedGCPClient (key: secret name, "" for default)
 	namespaceResolver config.NamespaceResolver
+	clientFactory     ClientFactory
 }
 
-// NewAuthHandler creates a new authentication handler. If nsResolver is nil, uses config.DefaultNamespaceResolver().
-func NewAuthHandler(nsResolver config.NamespaceResolver) service.Handler {
+// NewAuthHandler creates a new authentication handler. If nsResolver is nil, uses
+// config.DefaultNamespaceResolver(). Additional options (e.g., WithClientFactory) can be
+// supplied for testing.
+func NewAuthHandler(nsResolver config.NamespaceResolver, opts ...AuthHandlerOption) service.Handler {
 	if nsResolver == nil {
 		nsResolver = config.DefaultNamespaceResolver()
 	}
-	return &AuthHandler{namespaceResolver: nsResolver}
+	h := &AuthHandler{
+		namespaceResolver: nsResolver,
+		clientFactory:     defaultClientFactory,
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	return h
 }
 
-// Execute implements the Handler interface.
-// It sets up GCP authentication and initializes the API client.
+// Execute sets up GCP authentication and initializes the API client.
 func (h *AuthHandler) Execute(ctx *service.ReconciliationContext) error {
 	scaler := ctx.Scaler
 	var secret *corev1.Secret
-
+	cacheKey := "" // default credentials
 	if scaler.Spec.Config.AuthSecret != nil {
 		secret = &corev1.Secret{}
-		// Use operator namespace since GCP CRD is cluster-scoped (scaler.Namespace is empty)
+		// Use operator namespace since GCP CRD is cluster-scoped (scaler.Namespace is empty).
 		secretNamespace := h.namespaceResolver.Resolve()
 		namespacedSecret := types.NamespacedName{
 			Namespace: secretNamespace,
@@ -71,16 +115,43 @@ func (h *AuthHandler) Execute(ctx *service.ReconciliationContext) error {
 			return service.NewCriticalError(fmt.Errorf("fetch authentication secret: %w", err))
 		}
 		ctx.Secret = secret
+		cacheKey = *scaler.Spec.Config.AuthSecret
 	}
 
-	// Initialize GCP client
-	client, err := gcpClient.GetClient(ctx.Ctx, secret)
-	if err != nil {
-		ctx.Logger.Error().Err(err).Msg("unable to create GCP client")
-		return service.NewCriticalError(fmt.Errorf("create GCP client: %w", err))
+	var secretRV string
+	if secret != nil {
+		secretRV = secret.ResourceVersion
 	}
 
-	ctx.GCPClient = client
+	// Cache lookup: hit only when the stored entry was built from the same ResourceVersion.
+	// On mismatch we close the stale client before rebuilding so we don't leak connections.
+	var clientSet *gcpUtils.ClientSet
+	if cached, ok := h.clientCache.Load(cacheKey); ok {
+		if cc, _ := cached.(*cachedGCPClient); cc != nil {
+			if cc.resourceVersion == secretRV {
+				clientSet = cc.clientSet
+			} else {
+				if closeErr := cc.clientSet.Close(); closeErr != nil {
+					ctx.Logger.Warn().Err(closeErr).Msg("failed to close stale GCP client on rotation")
+				}
+			}
+		}
+	}
+
+	if clientSet == nil {
+		var err error
+		clientSet, err = h.clientFactory(ctx.Ctx, secret)
+		if err != nil {
+			ctx.Logger.Error().Err(err).Msg("unable to create GCP client")
+			return service.NewCriticalError(fmt.Errorf("create GCP client: %w", err))
+		}
+		h.clientCache.Store(cacheKey, &cachedGCPClient{
+			resourceVersion: secretRV,
+			clientSet:       clientSet,
+		})
+	}
+
+	ctx.GCPClient = clientSet
 	if h.next != nil && !ctx.SkipRemaining {
 		return h.next.Execute(ctx)
 	}

--- a/internal/controller/gcp/service/handlers/auth_handler.go
+++ b/internal/controller/gcp/service/handlers/auth_handler.go
@@ -19,7 +19,6 @@ package handlers
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -29,15 +28,6 @@ import (
 	gcpUtils "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils"
 	gcpClient "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils/client"
 )
-
-// cachedGCPClient holds a cached GCP client set together with the ResourceVersion of the
-// secret it was built from. When the secret is rotated (its ResourceVersion changes), the
-// cached entry is treated as stale and the client is rebuilt — otherwise revoked
-// credentials would remain usable until the controller restarts.
-type cachedGCPClient struct {
-	resourceVersion string
-	clientSet       *gcpUtils.ClientSet
-}
 
 // ClientFactory builds a GCP ClientSet from an optional auth secret.
 // Nil secret means use Application Default Credentials.
@@ -51,12 +41,26 @@ func defaultClientFactory(ctx context.Context, secret *corev1.Secret) (*gcpUtils
 // AuthHandlerOption configures an AuthHandler at construction time.
 type AuthHandlerOption func(*AuthHandler)
 
-// WithClientFactory overrides the default client factory. Intended for tests.
+// WithClientFactory overrides the default client factory. Intended for tests. Passing a
+// nil factory is a programmer error and panics immediately — silently keeping the default
+// would make a mis-wired test fail mysteriously when it hits real ADC instead of the stub.
 func WithClientFactory(factory ClientFactory) AuthHandlerOption {
+	if factory == nil {
+		panic("handlers.WithClientFactory: factory must not be nil")
+	}
 	return func(h *AuthHandler) {
-		if factory != nil {
-			h.clientFactory = factory
-		}
+		h.clientFactory = factory
+	}
+}
+
+// withClientCloser overrides the cache's Close seam. Package-private — only used by tests
+// in this package via a small white-box helper. Production must use the default.
+func withClientCloser(fn clientCloser) AuthHandlerOption {
+	if fn == nil {
+		panic("handlers.withClientCloser: fn must not be nil")
+	}
+	return func(h *AuthHandler) {
+		h.clientCache.close = fn
 	}
 }
 
@@ -65,8 +69,9 @@ func WithClientFactory(factory ClientFactory) AuthHandlerOption {
 //
 // Responsibilities:
 //   - Fetch authentication secret if specified
-//   - Cache the GCP ClientSet keyed by secret name + ResourceVersion so a rotation invalidates
-//     stale credentials, and successive reconciliations reuse the same client
+//   - Cache the GCP ClientSet keyed by (secret namespace, secret name) + ResourceVersion so
+//     a rotation invalidates stale credentials, and successive reconciliations reuse the
+//     same client
 //   - Populate GCPClient and Secret in context
 //
 // Error Handling:
@@ -74,7 +79,7 @@ func WithClientFactory(factory ClientFactory) AuthHandlerOption {
 //   - Client creation failure: Critical error (stops chain)
 type AuthHandler struct {
 	next              service.Handler
-	clientCache       sync.Map // map[string]*cachedGCPClient (key: secret name, "" for default)
+	clientCache       *gcpClientCache
 	namespaceResolver config.NamespaceResolver
 	clientFactory     ClientFactory
 }
@@ -88,6 +93,7 @@ func NewAuthHandler(nsResolver config.NamespaceResolver, opts ...AuthHandlerOpti
 	}
 	h := &AuthHandler{
 		namespaceResolver: nsResolver,
+		clientCache:       newGCPClientCache(),
 		clientFactory:     defaultClientFactory,
 	}
 	for _, opt := range opts {
@@ -100,10 +106,11 @@ func NewAuthHandler(nsResolver config.NamespaceResolver, opts ...AuthHandlerOpti
 func (h *AuthHandler) Execute(ctx *service.ReconciliationContext) error {
 	scaler := ctx.Scaler
 	var secret *corev1.Secret
-	cacheKey := "" // default credentials
+	var key cacheKey // zero value = ADC path
+
 	if scaler.Spec.Config.AuthSecret != nil {
 		secret = &corev1.Secret{}
-		// Use operator namespace since GCP CRD is cluster-scoped (scaler.Namespace is empty).
+		// GCP CRD is cluster-scoped; the secret namespace comes from the operator resolver.
 		secretNamespace := h.namespaceResolver.Resolve()
 		namespacedSecret := types.NamespacedName{
 			Namespace: secretNamespace,
@@ -115,7 +122,7 @@ func (h *AuthHandler) Execute(ctx *service.ReconciliationContext) error {
 			return service.NewCriticalError(fmt.Errorf("fetch authentication secret: %w", err))
 		}
 		ctx.Secret = secret
-		cacheKey = *scaler.Spec.Config.AuthSecret
+		key = cacheKey{namespace: secretNamespace, name: *scaler.Spec.Config.AuthSecret}
 	}
 
 	var secretRV string
@@ -123,32 +130,19 @@ func (h *AuthHandler) Execute(ctx *service.ReconciliationContext) error {
 		secretRV = secret.ResourceVersion
 	}
 
-	// Cache lookup: hit only when the stored entry was built from the same ResourceVersion.
-	// On mismatch we close the stale client before rebuilding so we don't leak connections.
-	var clientSet *gcpUtils.ClientSet
-	if cached, ok := h.clientCache.Load(cacheKey); ok {
-		if cc, _ := cached.(*cachedGCPClient); cc != nil {
-			if cc.resourceVersion == secretRV {
-				clientSet = cc.clientSet
-			} else {
-				if closeErr := cc.clientSet.Close(); closeErr != nil {
-					ctx.Logger.Warn().Err(closeErr).Msg("failed to close stale GCP client on rotation")
-				}
-			}
-		}
-	}
-
-	if clientSet == nil {
-		var err error
-		clientSet, err = h.clientFactory(ctx.Ctx, secret)
-		if err != nil {
+	clientSet, err := h.clientCache.GetOrBuild(key, secretRV, func() (*gcpUtils.ClientSet, error) {
+		return h.clientFactory(ctx.Ctx, secret)
+	})
+	if err != nil {
+		// Either the factory failed, or the factory succeeded but closing the prior stale
+		// client returned an error. Distinguish via the returned clientSet: if it's nil, the
+		// factory failed and we surface a critical error; otherwise we log the close error
+		// and proceed with the fresh client.
+		if clientSet == nil {
 			ctx.Logger.Error().Err(err).Msg("unable to create GCP client")
 			return service.NewCriticalError(fmt.Errorf("create GCP client: %w", err))
 		}
-		h.clientCache.Store(cacheKey, &cachedGCPClient{
-			resourceVersion: secretRV,
-			clientSet:       clientSet,
-		})
+		ctx.Logger.Warn().Err(err).Msg("failed to close stale GCP client on rotation")
 	}
 
 	ctx.GCPClient = clientSet

--- a/internal/controller/gcp/service/handlers/auth_handler_test.go
+++ b/internal/controller/gcp/service/handlers/auth_handler_test.go
@@ -19,6 +19,8 @@ package handlers_test
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,6 +37,8 @@ import (
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service/handlers"
 	gcpUtils "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils"
 )
+
+const testAuthSecretName = "gcp-secret"
 
 // stubNamespaceResolver returns a fixed namespace — keeps tests independent of POD_NAMESPACE.
 type stubNamespaceResolver struct{ ns string }
@@ -127,7 +131,7 @@ var _ = Describe("AuthHandler", func() {
 		var authSecret *corev1.Secret
 
 		BeforeEach(func() {
-			secretName := "gcp-secret"
+			secretName := testAuthSecretName
 			scaler.Spec.Config.AuthSecret = &secretName
 			authSecret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -175,6 +179,109 @@ var _ = Describe("AuthHandler", func() {
 
 			Expect(authHandler.Execute(reconCtx)).To(Succeed())
 			Expect(factory.invocations).To(HaveLen(2))
+		})
+	})
+
+	Context("When the secret is rotated", func() {
+		var (
+			authSecret *corev1.Secret
+			closes     atomic.Int32
+		)
+
+		BeforeEach(func() {
+			secretName := testAuthSecretName
+			scaler.Spec.Config.AuthSecret = &secretName
+			authSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            secretName,
+					Namespace:       "default",
+					ResourceVersion: "1",
+				},
+				Data: map[string][]byte{"service-account-key.json": []byte(`{"type":"service_account"}`)},
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler, authSecret).Build()
+
+			closes.Store(0)
+			factory = newStubGCPFactory()
+			authHandler = handlers.NewAuthHandler(
+				stubNamespaceResolver{ns: "default"},
+				handlers.WithClientFactory(factory.build),
+				handlers.WithClientCloserForTest(func(_ *gcpUtils.ClientSet) error {
+					closes.Add(1)
+					return nil
+				}),
+			)
+
+			reconCtx = &service.ReconciliationContext{
+				Ctx:     context.Background(),
+				Request: ctrl.Request{},
+				Client:  k8sClient,
+				Logger:  &logger,
+				Scaler:  scaler,
+			}
+		})
+
+		It("closes the stale client exactly once before storing the rebuilt client", func() {
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(closes.Load()).To(BeZero(), "no close on initial build")
+
+			rotated := &corev1.Secret{}
+			secretKey := types.NamespacedName{Namespace: authSecret.Namespace, Name: authSecret.Name}
+			Expect(reconCtx.Client.Get(reconCtx.Ctx, secretKey, rotated)).To(Succeed())
+			rotated.Data["service-account-key.json"] = []byte(`{"type":"rotated"}`)
+			Expect(reconCtx.Client.Update(reconCtx.Ctx, rotated)).To(Succeed())
+
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(factory.invocations).To(HaveLen(2))
+			Expect(closes.Load()).To(Equal(int32(1)), "close called exactly once on rotation")
+
+			// Third reconcile at the same RV must be a cache hit — no extra close, no extra build.
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(factory.invocations).To(HaveLen(2))
+			Expect(closes.Load()).To(Equal(int32(1)))
+		})
+	})
+
+	Context("Concurrent reconciles hitting the same cacheKey", func() {
+		It("is goroutine-safe (run with -race); factory invocations are bounded", func() {
+			secretName := testAuthSecretName
+			scaler.Spec.Config.AuthSecret = &secretName
+			authSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            secretName,
+					Namespace:       "default",
+					ResourceVersion: "1",
+				},
+				Data: map[string][]byte{"service-account-key.json": []byte(`{"type":"service_account"}`)},
+			}
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler, authSecret).Build()
+
+			const workers = 20
+			var wg sync.WaitGroup
+			for range workers {
+				wg.Go(func() {
+					local := &service.ReconciliationContext{
+						Ctx:     context.Background(),
+						Request: ctrl.Request{},
+						Client:  k8sClient,
+						Logger:  &logger,
+						Scaler:  scaler,
+					}
+					Expect(authHandler.Execute(local)).To(Succeed())
+				})
+			}
+			wg.Wait()
+
+			// Under the current single-mutex cache, concurrent misses may serialise but none should
+			// exceed the worker count, and at least one build must have happened.
+			Expect(factory.invocations).ToNot(BeEmpty())
+			Expect(len(factory.invocations)).To(BeNumerically("<=", workers))
+		})
+	})
+
+	Context("WithClientFactory with a nil factory", func() {
+		It("panics immediately — mis-wired tests must fail loudly, not fall through to ADC", func() {
+			Expect(func() { handlers.WithClientFactory(nil) }).To(Panic())
 		})
 	})
 

--- a/internal/controller/gcp/service/handlers/auth_handler_test.go
+++ b/internal/controller/gcp/service/handlers/auth_handler_test.go
@@ -18,6 +18,7 @@ package handlers_test
 
 import (
 	"context"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -25,14 +26,41 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/ptr"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service/handlers"
+	gcpUtils "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils"
 )
+
+// stubNamespaceResolver returns a fixed namespace — keeps tests independent of POD_NAMESPACE.
+type stubNamespaceResolver struct{ ns string }
+
+func (s stubNamespaceResolver) Resolve() string { return s.ns }
+
+// stubGCPFactory records invocations and returns a deterministic ClientSet (or error).
+type stubGCPFactory struct {
+	invocations []*corev1.Secret
+	clientSet   *gcpUtils.ClientSet
+	err         error
+}
+
+func (s *stubGCPFactory) build(_ context.Context, secret *corev1.Secret) (*gcpUtils.ClientSet, error) {
+	s.invocations = append(s.invocations, secret)
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.clientSet, nil
+}
+
+func newStubGCPFactory() *stubGCPFactory {
+	// Empty ClientSet is sufficient: the handler only passes it through to ctx.GCPClient.
+	// No GCP API calls happen during AuthHandler.Execute.
+	return &stubGCPFactory{clientSet: &gcpUtils.ClientSet{}}
+}
 
 var _ = Describe("AuthHandler", func() {
 	var (
@@ -41,6 +69,7 @@ var _ = Describe("AuthHandler", func() {
 		authHandler service.Handler
 		reconCtx    *service.ReconciliationContext
 		scaler      *kubecloudscalerv1alpha3.Gcp
+		factory     *stubGCPFactory
 	)
 
 	BeforeEach(func() {
@@ -54,18 +83,17 @@ var _ = Describe("AuthHandler", func() {
 		scaler.SetNamespace("default")
 		scaler.Spec.Config.ProjectID = "test-project"
 
-		authHandler = handlers.NewAuthHandler(nil)
+		factory = newStubGCPFactory()
+		authHandler = handlers.NewAuthHandler(
+			stubNamespaceResolver{ns: "default"},
+			handlers.WithClientFactory(factory.build),
+		)
 	})
 
 	Context("When auth secret is not specified", func() {
 		BeforeEach(func() {
-			// No auth secret specified
 			scaler.Spec.Config.AuthSecret = nil
-
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler).
-				Build()
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler).Build()
 
 			reconCtx = &service.ReconciliationContext{
 				Ctx:     context.Background(),
@@ -76,42 +104,40 @@ var _ = Describe("AuthHandler", func() {
 			}
 		})
 
-		It("should attempt to create GCP client with default credentials", func() {
-			err := authHandler.Execute(reconCtx)
-
-			// Behaviour depends on the environment:
-			// - In environments without ADC, client creation fails with a critical error.
-			// - In environments with ADC, client creation succeeds and GCPClient is populated.
-			if err != nil {
-				Expect(service.IsCriticalError(err)).To(BeTrue())
-				Expect(reconCtx.GCPClient).To(BeNil())
-			} else {
-				Expect(reconCtx.GCPClient).ToNot(BeNil())
-			}
+		It("should build a default-credentials client and expose it on the context", func() {
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.Secret).To(BeNil())
+			Expect(reconCtx.GCPClient).To(BeIdenticalTo(factory.clientSet))
+			Expect(factory.invocations).To(HaveLen(1))
+			Expect(factory.invocations[0]).To(BeNil())
 		})
 
+		It("should propagate factory errors as CriticalError", func() {
+			factory.err = fmt.Errorf("ADC unreachable")
+
+			err := authHandler.Execute(reconCtx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(service.IsCriticalError(err)).To(BeTrue())
+			Expect(reconCtx.GCPClient).To(BeNil())
+		})
 	})
 
 	Context("When auth secret is specified and exists", func() {
+		var authSecret *corev1.Secret
+
 		BeforeEach(func() {
 			secretName := "gcp-secret"
 			scaler.Spec.Config.AuthSecret = &secretName
-
-			// Create a mock secret in the operator namespace (where the handler looks)
-			secret := &corev1.Secret{
+			authSecret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: "kubecloudscaler-system",
+					Name:            secretName,
+					Namespace:       "default",
+					ResourceVersion: "1",
 				},
-				Data: map[string][]byte{
-					"credentials.json": []byte(`{"type": "service_account"}`),
-				},
+				Data: map[string][]byte{"service-account-key.json": []byte(`{"type":"service_account"}`)},
 			}
-
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler, secret).
-				Build()
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler, authSecret).Build()
 
 			reconCtx = &service.ReconciliationContext{
 				Ctx:     context.Background(),
@@ -122,16 +148,33 @@ var _ = Describe("AuthHandler", func() {
 			}
 		})
 
-		It("should fetch secret and attempt to create GCP client", func() {
-			err := authHandler.Execute(reconCtx)
+		It("should fetch the secret and build the client", func() {
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.Secret.Name).To(Equal(authSecret.Name))
+			Expect(reconCtx.GCPClient).To(BeIdenticalTo(factory.clientSet))
+			Expect(factory.invocations).To(HaveLen(1))
+		})
 
-			// Secret should be populated in context
-			Expect(reconCtx.Secret).ToNot(BeNil())
-			Expect(reconCtx.Secret.Name).To(Equal("gcp-secret"))
+		It("should reuse the cached client when the secret ResourceVersion is unchanged", func() {
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
 
-			// Client creation will fail without valid credentials, but that's expected
-			Expect(err).To(HaveOccurred())
-			Expect(service.IsCriticalError(err)).To(BeTrue())
+			// Second reconciliation must hit the cache, so factory is invoked only once.
+			Expect(factory.invocations).To(HaveLen(1))
+		})
+
+		It("should rebuild the client when the secret is rotated (ResourceVersion changes)", func() {
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+
+			// Simulate rotation: fetch latest, mutate, update — fake client bumps ResourceVersion.
+			rotated := &corev1.Secret{}
+			secretKey := types.NamespacedName{Namespace: authSecret.Namespace, Name: authSecret.Name}
+			Expect(reconCtx.Client.Get(reconCtx.Ctx, secretKey, rotated)).To(Succeed())
+			rotated.Data["service-account-key.json"] = []byte(`{"type":"rotated"}`)
+			Expect(reconCtx.Client.Update(reconCtx.Ctx, rotated)).To(Succeed())
+
+			Expect(authHandler.Execute(reconCtx)).To(Succeed())
+			Expect(factory.invocations).To(HaveLen(2))
 		})
 	})
 
@@ -139,11 +182,7 @@ var _ = Describe("AuthHandler", func() {
 		BeforeEach(func() {
 			secretName := "nonexistent-secret"
 			scaler.Spec.Config.AuthSecret = &secretName
-
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler).
-				Build()
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler).Build()
 
 			reconCtx = &service.ReconciliationContext{
 				Ctx:     context.Background(),
@@ -154,50 +193,13 @@ var _ = Describe("AuthHandler", func() {
 			}
 		})
 
-		It("should return a critical error", func() {
+		It("should return a critical error without invoking the factory", func() {
 			err := authHandler.Execute(reconCtx)
 
 			Expect(err).To(HaveOccurred())
 			Expect(service.IsCriticalError(err)).To(BeTrue())
 			Expect(reconCtx.Secret).To(BeNil())
-		})
-	})
-
-	Context("When scaler has minimal configuration", func() {
-		BeforeEach(func() {
-			scaler.Spec.Config.AuthSecret = ptr.To("test-secret")
-			scaler.Spec.Config.ProjectID = "test-project-123"
-
-			secret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-secret",
-					Namespace: "kubecloudscaler-system",
-				},
-			}
-
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler, secret).
-				Build()
-
-			reconCtx = &service.ReconciliationContext{
-				Ctx:     context.Background(),
-				Request: ctrl.Request{},
-				Client:  k8sClient,
-				Logger:  &logger,
-				Scaler:  scaler,
-			}
-		})
-
-		It("should handle configuration correctly", func() {
-			err := authHandler.Execute(reconCtx)
-
-			// Secret should be fetched
-			Expect(reconCtx.Secret).ToNot(BeNil())
-
-			// GCP client creation will fail without valid credentials
-			Expect(err).To(HaveOccurred())
-			Expect(service.IsCriticalError(err)).To(BeTrue())
+			Expect(factory.invocations).To(BeEmpty())
 		})
 	})
 })

--- a/internal/controller/gcp/service/handlers/export_test.go
+++ b/internal/controller/gcp/service/handlers/export_test.go
@@ -1,0 +1,30 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import gcpUtils "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/utils"
+
+// Test-only exports compiled only into the test binary.
+
+// ClientCloserForTest is the signature of the cache's Close seam, re-exported so tests
+// can observe close-on-rotation deterministically.
+type ClientCloserForTest func(cs *gcpUtils.ClientSet) error
+
+// WithClientCloserForTest exposes the unexported withClientCloser option.
+func WithClientCloserForTest(fn ClientCloserForTest) AuthHandlerOption {
+	return withClientCloser(clientCloser(fn))
+}

--- a/internal/controller/gcp/service/handlers/fetch_handler.go
+++ b/internal/controller/gcp/service/handlers/fetch_handler.go
@@ -58,6 +58,10 @@ func (h *FetchHandler) Execute(ctx *service.ReconciliationContext) error {
 	scaler := &kubecloudscalerv1alpha3.Gcp{}
 	if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, scaler); err != nil {
 		if client.IgnoreNotFound(err) == nil {
+			// Scaler is gone (likely deleted). Short-circuit without an error so
+			// controller-runtime does not log a spurious "Reconciler error"; the
+			// Debug log keeps this path observable when troubleshooting.
+			ctx.Logger.Debug().Msg("scaler not found, skipping reconciliation (likely deleted)")
 			ctx.SkipRemaining = true
 			return nil
 		}
@@ -67,7 +71,6 @@ func (h *FetchHandler) Execute(ctx *service.ReconciliationContext) error {
 	}
 
 	ctx.Scaler = scaler
-	ctx.ScalerOriginal = scaler.DeepCopy()
 	if h.next != nil {
 		return h.next.Execute(ctx)
 	}

--- a/internal/controller/gcp/service/handlers/fetch_handler.go
+++ b/internal/controller/gcp/service/handlers/fetch_handler.go
@@ -67,6 +67,7 @@ func (h *FetchHandler) Execute(ctx *service.ReconciliationContext) error {
 	}
 
 	ctx.Scaler = scaler
+	ctx.ScalerOriginal = scaler.DeepCopy()
 	if h.next != nil {
 		return h.next.Execute(ctx)
 	}

--- a/internal/controller/gcp/service/handlers/finalizer_handler.go
+++ b/internal/controller/gcp/service/handlers/finalizer_handler.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -62,6 +63,12 @@ func (h *FinalizerHandler) Execute(ctx *service.ReconciliationContext) error {
 		if !controllerutil.ContainsFinalizer(scaler, ScalerFinalizer) {
 			ctx.Logger.Info().Msg("adding finalizer")
 			if err := patchAddFinalizer(ctx); err != nil {
+				if apierrors.IsNotFound(err) {
+					// Scaler was deleted between FetchHandler and this patch — nothing to do.
+					ctx.Logger.Debug().Msg("scaler vanished before finalizer could be added, skipping")
+					ctx.SkipRemaining = true
+					return nil
+				}
 				ctx.Logger.Error().Err(err).Msg("failed to add finalizer")
 				ctx.RequeueAfter = transientRequeueAfter
 				return service.NewRecoverableError(fmt.Errorf("add finalizer: %w", err))

--- a/internal/controller/gcp/service/handlers/finalizer_handler.go
+++ b/internal/controller/gcp/service/handlers/finalizer_handler.go
@@ -19,8 +19,12 @@ package handlers
 import (
 	"fmt"
 
-	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
 )
 
 const (
@@ -57,12 +61,12 @@ func (h *FinalizerHandler) Execute(ctx *service.ReconciliationContext) error {
 		// Object is not being deleted - ensure finalizer is present
 		if !controllerutil.ContainsFinalizer(scaler, ScalerFinalizer) {
 			ctx.Logger.Info().Msg("adding finalizer")
-			controllerutil.AddFinalizer(scaler, ScalerFinalizer)
-			if err := ctx.Client.Update(ctx.Ctx, scaler); err != nil {
+			if err := patchAddFinalizer(ctx); err != nil {
 				ctx.Logger.Error().Err(err).Msg("failed to add finalizer")
 				ctx.RequeueAfter = transientRequeueAfter
 				return service.NewRecoverableError(fmt.Errorf("add finalizer: %w", err))
 			}
+			controllerutil.AddFinalizer(scaler, ScalerFinalizer)
 		}
 		// Finalizer present or added successfully, continue chain
 		if h.next != nil && !ctx.SkipRemaining {
@@ -82,8 +86,9 @@ func (h *FinalizerHandler) Execute(ctx *service.ReconciliationContext) error {
 		return nil
 	}
 
-	// Finalizer already removed - skip remaining handlers
-	ctx.Logger.Info().Msg("finalizer already removed, skipping reconciliation")
+	// Finalizer already removed - skip remaining handlers. Debug level to avoid
+	// log spam while the object lingers awaiting garbage collection.
+	ctx.Logger.Debug().Msg("finalizer already removed, skipping reconciliation")
 	ctx.SkipRemaining = true
 	return nil
 }
@@ -91,4 +96,22 @@ func (h *FinalizerHandler) Execute(ctx *service.ReconciliationContext) error {
 // SetNext sets the next handler in the chain.
 func (h *FinalizerHandler) SetNext(next service.Handler) {
 	h.next = next
+}
+
+// patchAddFinalizer adds ScalerFinalizer via an optimistic-locked merge patch, re-fetching
+// and retrying on 409 conflicts. Scoped to metadata.finalizers so neither spec nor status is
+// transmitted. No-op if another reconcile added the finalizer concurrently.
+func patchAddFinalizer(ctx *service.ReconciliationContext) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &kubecloudscalerv1alpha3.Gcp{}
+		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, latest); err != nil {
+			return err
+		}
+		if controllerutil.ContainsFinalizer(latest, ScalerFinalizer) {
+			return nil
+		}
+		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		controllerutil.AddFinalizer(latest, ScalerFinalizer)
+		return ctx.Client.Patch(ctx.Ctx, latest, patch)
+	})
 }

--- a/internal/controller/gcp/service/handlers/finalizer_handler_test.go
+++ b/internal/controller/gcp/service/handlers/finalizer_handler_test.go
@@ -24,8 +24,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rs/zerolog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -193,6 +195,60 @@ var _ = Describe("FinalizerHandler", func() {
 
 			Expect(err).ToNot(HaveOccurred())
 			Expect(reconCtx.SkipRemaining).To(BeTrue())
+		})
+	})
+
+	Context("When the scaler is deleted between Fetch and finalizer Patch", func() {
+		It("short-circuits without error and without requeue", func() {
+			// Empty fake client — any Get inside patchAddFinalizer returns NotFound.
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			reconCtx = &service.ReconciliationContext{
+				Ctx:     context.Background(),
+				Request: ctrl.Request{NamespacedName: types.NamespacedName{Name: scaler.Name, Namespace: scaler.Namespace}},
+				Client:  k8sClient,
+				Logger:  &logger,
+				Scaler:  scaler,
+			}
+
+			err := finalizerHandler.Execute(reconCtx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reconCtx.SkipRemaining).To(BeTrue())
+			Expect(reconCtx.RequeueAfter).To(BeZero())
+		})
+	})
+
+	Context("Retry-on-conflict when adding the finalizer", func() {
+		It("retries once on a 409 and succeeds on the second Patch", func() {
+			gvr := schema.GroupResource{Group: "kubecloudscaler.cloud", Resource: "gcps"}
+			var patchCalls int
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(scaler).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCalls++
+						if patchCalls == 1 {
+							return apierrors.NewConflict(gvr, obj.GetName(), fmt.Errorf("conflict"))
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			reconCtx = &service.ReconciliationContext{
+				Ctx:     context.Background(),
+				Request: ctrl.Request{NamespacedName: types.NamespacedName{Name: scaler.Name, Namespace: scaler.Namespace}},
+				Client:  k8sClient,
+				Logger:  &logger,
+				Scaler:  scaler,
+			}
+
+			Expect(finalizerHandler.Execute(reconCtx)).To(Succeed())
+			Expect(patchCalls).To(Equal(2))
+			persisted := &kubecloudscalerv1alpha3.Gcp{}
+			Expect(k8sClient.Get(reconCtx.Ctx, reconCtx.Request.NamespacedName, persisted)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(persisted, handlers.ScalerFinalizer)).To(BeTrue())
 		})
 	})
 })

--- a/internal/controller/gcp/service/handlers/finalizer_handler_test.go
+++ b/internal/controller/gcp/service/handlers/finalizer_handler_test.go
@@ -26,10 +26,13 @@ import (
 	"github.com/rs/zerolog"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
@@ -59,14 +62,10 @@ var _ = Describe("FinalizerHandler", func() {
 
 	Context("When scaler is not being deleted and has no finalizer", func() {
 		BeforeEach(func() {
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler).
-				Build()
-
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler).Build()
 			reconCtx = &service.ReconciliationContext{
 				Ctx:     context.Background(),
-				Request: ctrl.Request{},
+				Request: ctrl.Request{NamespacedName: types.NamespacedName{Name: scaler.Name, Namespace: scaler.Namespace}},
 				Client:  k8sClient,
 				Logger:  &logger,
 				Scaler:  scaler,
@@ -81,26 +80,27 @@ var _ = Describe("FinalizerHandler", func() {
 		})
 	})
 
-	Context("When client Update fails while adding finalizer", func() {
+	Context("When client Patch fails while adding finalizer", func() {
 		BeforeEach(func() {
 			k8sClient := fake.NewClientBuilder().
 				WithScheme(scheme).
 				WithObjects(scaler).
 				WithInterceptorFuncs(interceptor.Funcs{
-					Update: func(
+					Patch: func(
 						ctx context.Context,
 						c client.WithWatch,
 						obj client.Object,
-						opts ...client.UpdateOption,
+						patch client.Patch,
+						opts ...client.PatchOption,
 					) error {
-						return fmt.Errorf("conflict on update")
+						return fmt.Errorf("persistent patch failure")
 					},
 				}).
 				Build()
 
 			reconCtx = &service.ReconciliationContext{
 				Ctx:     context.Background(),
-				Request: ctrl.Request{},
+				Request: ctrl.Request{NamespacedName: types.NamespacedName{Name: scaler.Name, Namespace: scaler.Namespace}},
 				Client:  k8sClient,
 				Logger:  &logger,
 				Scaler:  scaler,
@@ -113,6 +113,29 @@ var _ = Describe("FinalizerHandler", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(service.IsRecoverableError(err)).To(BeTrue())
 			Expect(reconCtx.RequeueAfter).To(Equal(5 * time.Second))
+		})
+	})
+
+	Context("When adding the finalizer succeeds", func() {
+		BeforeEach(func() {
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler).Build()
+			reconCtx = &service.ReconciliationContext{
+				Ctx:     context.Background(),
+				Request: ctrl.Request{NamespacedName: types.NamespacedName{Name: scaler.Name, Namespace: scaler.Namespace}},
+				Client:  k8sClient,
+				Logger:  &logger,
+				Scaler:  scaler,
+			}
+		})
+
+		It("should persist the finalizer via Patch and update ctx.Scaler", func() {
+			Expect(finalizerHandler.Execute(reconCtx)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(reconCtx.Scaler, handlers.ScalerFinalizer)).To(BeTrue())
+
+			// Verify persisted on the server (not just in-memory).
+			persisted := &kubecloudscalerv1alpha3.Gcp{}
+			Expect(reconCtx.Client.Get(reconCtx.Ctx, reconCtx.Request.NamespacedName, persisted)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(persisted, handlers.ScalerFinalizer)).To(BeTrue())
 		})
 	})
 

--- a/internal/controller/gcp/service/handlers/period_handler_test.go
+++ b/internal/controller/gcp/service/handlers/period_handler_test.go
@@ -126,6 +126,9 @@ var _ = Describe("PeriodHandler", func() {
 			Expect(periodHandler.Execute(reconCtx)).To(Succeed())
 			Expect(reconCtx.SkipRemaining).To(BeFalse())
 			Expect(reconCtx.Period).ToNot(BeNil())
+			Expect(reconCtx.Period.Name).To(Equal("noaction"))
+			Expect(reconCtx.Scaler.Status.CurrentPeriod).ToNot(BeNil())
+			Expect(reconCtx.Scaler.Status.CurrentPeriod.Name).To(Equal("noaction"))
 		})
 	})
 
@@ -184,34 +187,6 @@ var _ = Describe("PeriodHandler", func() {
 		})
 	})
 
-	Context("When period configuration is empty", func() {
-		BeforeEach(func() {
-			scaler.Spec.Periods = []common.ScalerPeriod{}
-
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler).
-				Build()
-
-			reconCtx = &service.ReconciliationContext{
-				Ctx:       context.Background(),
-				Request:   ctrl.Request{},
-				Client:    k8sClient,
-				Logger:    &logger,
-				Scaler:    scaler,
-				GCPClient: &gcpUtils.ClientSet{},
-			}
-		})
-
-		It("should handle empty periods gracefully", func() {
-			err := periodHandler.Execute(reconCtx)
-
-			// Should either succeed with default period or return appropriate result
-			// Error handling depends on implementation
-			_ = err
-		})
-	})
-
 	Context("When handling finalizer deletion", func() {
 		BeforeEach(func() {
 			scaler.Spec.Config.RestoreOnDelete = true
@@ -246,11 +221,9 @@ var _ = Describe("PeriodHandler", func() {
 			}
 		})
 
-		It("should handle restore on delete", func() {
-			err := periodHandler.Execute(reconCtx)
-
-			// Validation with restore flag should work
-			_ = err
+		It("should succeed and keep the chain alive so the scaling handler can restore state", func() {
+			Expect(periodHandler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.SkipRemaining).To(BeFalse())
 		})
 	})
 })

--- a/internal/controller/gcp/service/handlers/period_handler_test.go
+++ b/internal/controller/gcp/service/handlers/period_handler_test.go
@@ -58,46 +58,75 @@ var _ = Describe("PeriodHandler", func() {
 		periodHandler = handlers.NewPeriodHandler()
 	})
 
-	Context("When period configuration is valid", func() {
+	Context("When an always-active period is configured", func() {
 		BeforeEach(func() {
+			// Every day across the full 24h window — eliminates time-based non-determinism.
 			scaler.Spec.Periods = []common.ScalerPeriod{
 				{
-					Name: "business-hours",
+					Name: "always-up",
 					Type: common.PeriodTypeUp,
 					Time: common.TimePeriod{
 						Recurring: &common.RecurringPeriod{
-							Days:      []common.DayOfWeek{common.DayMonday, common.DayTuesday, common.DayWednesday, common.DayThursday, common.DayFriday},
-							StartTime: "09:00",
-							EndTime:   "17:00",
+							Days:      []common.DayOfWeek{common.DayAll},
+							StartTime: "00:00",
+							EndTime:   "23:59",
 							Once:      ptr.To(false),
 						},
 					},
 				},
 			}
 
-			k8sClient := fake.NewClientBuilder().
-				WithScheme(scheme).
-				WithObjects(scaler).
-				Build()
-
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler).Build()
 			reconCtx = &service.ReconciliationContext{
 				Ctx:       context.Background(),
 				Request:   ctrl.Request{},
 				Client:    k8sClient,
 				Logger:    &logger,
 				Scaler:    scaler,
-				GCPClient: &gcpUtils.ClientSet{}, // Mock GCP client
+				GCPClient: &gcpUtils.ClientSet{},
 			}
 		})
 
-		It("should validate period and populate context", func() {
-			err := periodHandler.Execute(reconCtx)
+		It("should resolve the period and populate the context deterministically", func() {
+			Expect(periodHandler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.Period).ToNot(BeNil())
+			Expect(reconCtx.Period.Name).To(Equal("always-up"))
+			Expect(reconCtx.SkipRemaining).To(BeFalse())
+		})
+	})
 
-			// Period validation should succeed (or return appropriate result)
-			// The actual validation depends on current time
-			Expect(err).ToNot(HaveOccurred())
+	Context("When transitioning from an active period to noaction", func() {
+		BeforeEach(func() {
+			// Empty Spec.Periods forces SetActivePeriod to return the system-fallback noaction.
+			// Status.CurrentPeriod captures the previous active period so prevPeriodName != "noaction".
+			scaler.Spec.Periods = []common.ScalerPeriod{}
+			scaler.Status = common.ScalerStatus{
+				CurrentPeriod: &common.ScalerStatusPeriod{
+					Name: "business-hours",
+					Type: string(common.PeriodTypeUp),
+				},
+			}
+
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scaler).Build()
+			reconCtx = &service.ReconciliationContext{
+				Ctx:       context.Background(),
+				Request:   ctrl.Request{},
+				Client:    k8sClient,
+				Logger:    &logger,
+				Scaler:    scaler,
+				GCPClient: &gcpUtils.ClientSet{},
+			}
 		})
 
+		It("should NOT skip remaining — scaling handler must run to restore resource state", func() {
+			// Regression guard for the 4db0412 fix: prevPeriodName must be snapshotted BEFORE
+			// SetActivePeriod rewrites status.CurrentPeriod. If the snapshot moves after the
+			// call, every reconcile sees prevPeriodName == "noaction" and the chain skips
+			// silently, leaving resources in the wrong state.
+			Expect(periodHandler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.SkipRemaining).To(BeFalse())
+			Expect(reconCtx.Period).ToNot(BeNil())
+		})
 	})
 
 	Context("When period is 'noaction' and status matches", func() {

--- a/internal/controller/gcp/service/handlers/status_handler.go
+++ b/internal/controller/gcp/service/handlers/status_handler.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,6 +60,11 @@ func (h *StatusHandler) Execute(ctx *service.ReconciliationContext) error {
 	if ctx.ShouldFinalize {
 		ctx.Logger.Info().Str("name", scaler.Name).Msg("removing finalizer")
 		if err := patchRemoveFinalizer(ctx); err != nil {
+			if apierrors.IsNotFound(err) {
+				// Scaler has already been fully deleted — cleanup is done.
+				ctx.Logger.Debug().Msg("scaler already gone, finalizer cleanup is a no-op")
+				return nil
+			}
 			ctx.Logger.Error().Err(err).Msg("failed to remove finalizer")
 			ctx.RequeueAfter = transientRequeueAfter
 			return service.NewRecoverableError(fmt.Errorf("remove finalizer: %w", err))

--- a/internal/controller/gcp/service/handlers/status_handler.go
+++ b/internal/controller/gcp/service/handlers/status_handler.go
@@ -21,9 +21,11 @@ import (
 
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/kubecloudscaler/kubecloudscaler/api/common"
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/gcp/service"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/utils"
 )
@@ -56,19 +58,20 @@ func (h *StatusHandler) Execute(ctx *service.ReconciliationContext) error {
 
 	if ctx.ShouldFinalize {
 		ctx.Logger.Info().Str("name", scaler.Name).Msg("removing finalizer")
-		controllerutil.RemoveFinalizer(scaler, ScalerFinalizer)
-		if err := ctx.Client.Update(ctx.Ctx, scaler); err != nil {
+		if err := patchRemoveFinalizer(ctx); err != nil {
 			ctx.Logger.Error().Err(err).Msg("failed to remove finalizer")
 			ctx.RequeueAfter = transientRequeueAfter
 			return service.NewRecoverableError(fmt.Errorf("remove finalizer: %w", err))
 		}
+		controllerutil.RemoveFinalizer(scaler, ScalerFinalizer)
 		// Finalizer removed successfully, stop chain
 		return nil
 	}
 
 	// Build the desired status from the in-memory state set by PeriodHandler and ScalingHandler.
-	// This must be snapshotted before the retry loop because re-fetching the object from the
-	// cluster would overwrite fields like Spec/SpecSHA/Type/Name that PeriodHandler wrote.
+	// Snapshot via DeepCopy before the retry loop: re-fetching overwrites fields like
+	// Spec/SpecSHA/Type/Name that PeriodHandler wrote, and a shallow *scaler.Status.CurrentPeriod
+	// would alias the `Spec *TimePeriod` pointer and the Successful/Failed slices.
 	if scaler.Status.CurrentPeriod == nil {
 		scaler.Status.CurrentPeriod = &common.ScalerStatusPeriod{}
 	}
@@ -76,7 +79,7 @@ func (h *StatusHandler) Execute(ctx *service.ReconciliationContext) error {
 	scaler.Status.CurrentPeriod.Failed = ctx.FailedResults
 	scaler.Status.Comments = ptr.To("time period processed")
 
-	desiredPeriod := *scaler.Status.CurrentPeriod
+	desiredPeriod := scaler.Status.CurrentPeriod.DeepCopy()
 	desiredComments := scaler.Status.Comments
 
 	// Persist status updates to the cluster, retrying on conflict by re-fetching the latest version
@@ -84,9 +87,8 @@ func (h *StatusHandler) Execute(ctx *service.ReconciliationContext) error {
 		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, scaler); err != nil {
 			return err
 		}
-		// Restore desired status onto the freshly-fetched object (preserves resourceVersion)
-		periodCopy := desiredPeriod
-		scaler.Status.CurrentPeriod = &periodCopy
+		// Restore desired status onto the freshly-fetched object (preserves resourceVersion).
+		scaler.Status.CurrentPeriod = desiredPeriod.DeepCopy()
 		scaler.Status.Comments = desiredComments
 		return ctx.Client.Status().Update(ctx.Ctx, scaler)
 	}); err != nil {
@@ -114,4 +116,22 @@ func (h *StatusHandler) Execute(ctx *service.ReconciliationContext) error {
 // SetNext sets the next handler in the chain.
 func (h *StatusHandler) SetNext(next service.Handler) {
 	h.next = next
+}
+
+// patchRemoveFinalizer removes ScalerFinalizer via an optimistic-locked merge patch, re-fetching
+// and retrying on 409 conflicts. Scoped to metadata.finalizers so neither spec nor status is
+// transmitted. No-op if the finalizer is already absent.
+func patchRemoveFinalizer(ctx *service.ReconciliationContext) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &kubecloudscalerv1alpha3.Gcp{}
+		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, latest); err != nil {
+			return err
+		}
+		if !controllerutil.ContainsFinalizer(latest, ScalerFinalizer) {
+			return nil
+		}
+		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		controllerutil.RemoveFinalizer(latest, ScalerFinalizer)
+		return ctx.Client.Patch(ctx.Ctx, latest, patch)
+	})
 }

--- a/internal/controller/gcp/service/handlers/status_handler_test.go
+++ b/internal/controller/gcp/service/handlers/status_handler_test.go
@@ -24,7 +24,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rs/zerolog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -220,6 +223,150 @@ var _ = Describe("StatusHandler", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(service.IsRecoverableError(err)).To(BeTrue())
 			Expect(reconCtx.RequeueAfter).To(Equal(5 * time.Second))
+		})
+	})
+
+	Context("DeepCopy isolation between snapshot and Get-overwritten scaler", func() {
+		It("writes the ctx-sourced Successful/Failed slices, not the server-side state", func() {
+			// Pre-populate the server-side Status with different slice contents than what the
+			// handler will write from ctx — a shallow *scaler.Status.CurrentPeriod copy would
+			// alias the Successful/Failed slices and surface server state after the Get.
+			serverScaler := scaler.DeepCopy()
+			serverScaler.Status.CurrentPeriod = &common.ScalerStatusPeriod{
+				Name:       "prior-period",
+				Successful: []common.ScalerStatusSuccess{{Name: "stale-from-server", Kind: "instance"}},
+				Failed:     []common.ScalerStatusFailed{{Name: "stale-failed", Kind: "instance", Reason: "old"}},
+			}
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(serverScaler).
+				WithStatusSubresource(serverScaler).
+				Build()
+
+			reconCtx = &service.ReconciliationContext{
+				Ctx:     context.Background(),
+				Request: ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-scaler", Namespace: "default"}},
+				Client:  k8sClient,
+				Logger:  &logger,
+				Scaler:  scaler,
+				SuccessResults: []common.ScalerStatusSuccess{
+					{Name: "fresh-success", Kind: "instance"},
+				},
+				FailedResults: []common.ScalerStatusFailed{},
+			}
+
+			Expect(statusHandler.Execute(reconCtx)).To(Succeed())
+
+			persisted := &kubecloudscalerv1alpha3.Gcp{}
+			Expect(k8sClient.Get(reconCtx.Ctx, reconCtx.Request.NamespacedName, persisted)).To(Succeed())
+			Expect(persisted.Status.CurrentPeriod).ToNot(BeNil())
+			Expect(persisted.Status.CurrentPeriod.Successful).To(ConsistOf(
+				common.ScalerStatusSuccess{Name: "fresh-success", Kind: "instance"},
+			))
+			Expect(persisted.Status.CurrentPeriod.Failed).To(BeEmpty())
+
+			// Mutate the ctx source after the write — persisted data must not shift (no alias).
+			reconCtx.SuccessResults[0].Name = "mutated-after-write"
+			Expect(persisted.Status.CurrentPeriod.Successful[0].Name).To(Equal("fresh-success"))
+		})
+	})
+
+	Context("Retry-on-conflict when updating status", func() {
+		It("retries once on a 409 and succeeds on the second Update", func() {
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(scaler).
+				WithStatusSubresource(scaler).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func() func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+						var calls int
+						gvr := schema.GroupResource{Group: "kubecloudscaler.cloud", Resource: "gcps"}
+						return func(ctx context.Context, c client.Client, _ string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+							calls++
+							if calls == 1 {
+								return apierrors.NewConflict(gvr, obj.GetName(), fmt.Errorf("conflict"))
+							}
+							return c.Status().Update(ctx, obj, opts...)
+						}
+					}(),
+				}).
+				Build()
+
+			reconCtx = &service.ReconciliationContext{
+				Ctx:            context.Background(),
+				Request:        ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-scaler", Namespace: "default"}},
+				Client:         k8sClient,
+				Logger:         &logger,
+				Scaler:         scaler,
+				SuccessResults: []common.ScalerStatusSuccess{{Name: "ok", Kind: "instance"}},
+				FailedResults:  []common.ScalerStatusFailed{},
+			}
+
+			Expect(statusHandler.Execute(reconCtx)).To(Succeed())
+
+			persisted := &kubecloudscalerv1alpha3.Gcp{}
+			Expect(k8sClient.Get(reconCtx.Ctx, reconCtx.Request.NamespacedName, persisted)).To(Succeed())
+			Expect(persisted.Status.CurrentPeriod.Successful).To(ConsistOf(
+				common.ScalerStatusSuccess{Name: "ok", Kind: "instance"},
+			))
+		})
+	})
+
+	Context("When the scaler is deleted between Fetch and the finalizer-remove Patch", func() {
+		It("completes without error (cleanup is idempotent)", func() {
+			scaler.SetFinalizers([]string{handlers.ScalerFinalizer})
+			// Fake client WITHOUT the scaler — any Get inside patchRemoveFinalizer returns NotFound.
+			k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			reconCtx = &service.ReconciliationContext{
+				Ctx:            context.Background(),
+				Request:        ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-scaler", Namespace: "default"}},
+				Client:         k8sClient,
+				Logger:         &logger,
+				Scaler:         scaler,
+				ShouldFinalize: true,
+			}
+
+			err := statusHandler.Execute(reconCtx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(reconCtx.RequeueAfter).To(BeZero())
+		})
+	})
+
+	Context("Retry-on-conflict when removing the finalizer", func() {
+		It("retries once on a 409 and succeeds on the second Patch", func() {
+			scaler.SetFinalizers([]string{handlers.ScalerFinalizer})
+			now := metav1.Now()
+			scaler.SetDeletionTimestamp(&now)
+
+			gvr := schema.GroupResource{Group: "kubecloudscaler.cloud", Resource: "gcps"}
+			var patchCalls int
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(scaler).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCalls++
+						if patchCalls == 1 {
+							return apierrors.NewConflict(gvr, obj.GetName(), fmt.Errorf("conflict"))
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			reconCtx = &service.ReconciliationContext{
+				Ctx:            context.Background(),
+				Request:        ctrl.Request{NamespacedName: types.NamespacedName{Name: "test-scaler", Namespace: "default"}},
+				Client:         k8sClient,
+				Logger:         &logger,
+				Scaler:         scaler,
+				ShouldFinalize: true,
+			}
+
+			Expect(statusHandler.Execute(reconCtx)).To(Succeed())
+			Expect(patchCalls).To(Equal(2))
 		})
 	})
 

--- a/internal/controller/gcp/service/handlers/status_handler_test.go
+++ b/internal/controller/gcp/service/handlers/status_handler_test.go
@@ -145,7 +145,7 @@ var _ = Describe("StatusHandler", func() {
 		})
 	})
 
-	Context("When client Update fails during finalizer removal", func() {
+	Context("When client Patch fails during finalizer removal", func() {
 		BeforeEach(func() {
 			scaler.SetFinalizers([]string{handlers.ScalerFinalizer})
 
@@ -153,13 +153,14 @@ var _ = Describe("StatusHandler", func() {
 				WithScheme(scheme).
 				WithObjects(scaler).
 				WithInterceptorFuncs(interceptor.Funcs{
-					Update: func(
+					Patch: func(
 						ctx context.Context,
 						c client.WithWatch,
 						obj client.Object,
-						opts ...client.UpdateOption,
+						patch client.Patch,
+						opts ...client.PatchOption,
 					) error {
-						return fmt.Errorf("update conflict")
+						return fmt.Errorf("persistent patch failure")
 					},
 				}).
 				Build()


### PR DESCRIPTION
## Summary

Brings the GCP controller to parity with the recently-hardened k8s controller (PR #256). Addresses all Critical findings and the Important items from the GCP code review — applying the same Patch-over-Update / cache-with-rotation / deterministic-tests patterns, adapted for the GCP ClientSet.

### Critical

- **AuthHandler cache + rotation** — GCP client was rebuilt on every reconcile and immediately closed by the controller, defeating any reuse and churning TLS connections. Now cached keyed by `(secretName, secret.ResourceVersion)`, stale entries are closed on rotation, and the controller no longer calls `Close()` itself.
- **ClientFactory DI** — `WithClientFactory` functional option on `NewAuthHandler` so tests inject a deterministic stub. The previous tests branched on ADC availability and one of them used the wrong secret data key (`credentials.json` vs the expected `service-account-key.json`), passing only by accident.
- **Finalizer Patch + retry** — `FinalizerHandler` and `StatusHandler` now use `client.Patch` with `MergeFromWithOptimisticLock` + `retry.RetryOnConflict`, scoped to `metadata.finalizers`. No more full-object `Update` sending spec+status together, and 409s are retried by re-fetching.

### Important

- **`ScalerOriginal` field** on `ReconciliationContext`, populated by `FetchHandler` via `DeepCopy()` — pristine patch base for future use.
- **`StatusHandler` DeepCopy snapshot** — `desiredPeriod := *scaler.Status.CurrentPeriod` was a shallow copy aliasing `Spec *TimePeriod` and the `Successful/Failed` slices. Replaced with `DeepCopy()`.
- **Deterministic tests** — `auth_handler_test` (stub factory with cache-hit / rotation-rebuild assertions), `scaler_controller_test` (NotFound deterministic path), `compatibility_test` (fixed a misleading comment claiming `FetchHandler` returns `CriticalError` on NotFound; it returns nil).
- **`PeriodHandler` regression test** — new test seeds `Status.CurrentPeriod` with a previously-active period and empty `Spec.Periods` so `SetActivePeriod` falls back to noaction. Asserts `SkipRemaining == false` so future refactors can't silently re-introduce the bug fixed in commit 4db0412 (prevPeriodName snapshot being taken *after* `SetActivePeriod`).
- **Always-active period fixture** in the PeriodHandler happy-path test so the assertion no longer flips on wall-clock time.
- **Log downgrade** — `finalizer already removed` now logs at Debug instead of Info to avoid spam during GC of deleted resources.

## Follow-up review fixes (`9d34e44`)

A second review pass surfaced a behavioural bug class shared with the Flow controller and several hardening gaps. All addressed in one commit.

### Behavioural fixes

- **NotFound on finalizer re-Get** is now a no-op in both `patchAddFinalizer` and `patchRemoveFinalizer` (scaler was deleted between Fetch and Patch) instead of a `RecoverableError` hot-loop on a tombstoned object.
- **FetchHandler NotFound path** now emits a Debug log so the skip path is traceable.

### Cache type extraction

- New `gcpClientCache` type replaces the inline `sync.Map` in `AuthHandler`:
  - Typed `map[cacheKey]*cachedGCPClient` + cache-wide mutex serialises `Get`-or-build — concurrent reconciles for the same `cacheKey` no longer double-store or double-close.
  - Struct key `{namespace, name}` replaces the bare secret-name string; defends against a future per-scaler namespace refactor where two `gcp-sa` secrets in different namespaces would otherwise collide.
  - `clientCloser` seam injectable via the test-only `WithClientCloserForTest` option; close-on-rotation is now directly observable (exactly-once assertion) instead of opaque.

### Dead-code removal

- `ScalerOriginal` field + FetchHandler DeepCopy write removed. The doc comment claimed "Used by: FinalizerHandler, StatusHandler" but neither handler referenced it — `patchAddFinalizer` / `patchRemoveFinalizer` build their patch base from a freshly-fetched `latest.DeepCopy` inside the retry closure. Per "no premature abstractions" the field went back into the box rather than forward.

### Mis-wiring guard

- `WithClientFactory(nil)` now **panics at option-build time** instead of silently keeping the default. A mis-wired test that forgot to build its stub factory would previously fall through to real ADC; now it fails loudly.

### New tests

- AuthHandler: close-on-rotation exactly-once counter via the closer seam, concurrent `Execute` under `-race` (20 workers), `WithClientFactory(nil)` panic assertion.
- FinalizerHandler: NotFound mid-reconcile short-circuits cleanly, retry-on-conflict succeeds on the second Patch.
- StatusHandler: DeepCopy isolation — pre-populate server-side `Status.CurrentPeriod` with different slices, assert the persisted data matches the ctx snapshot (not the server state), plus mutate-after-write to prove no alias. Retry-on-conflict on status Update and on finalizer-remove Patch. NotFound mid-remove is idempotent.
- PeriodHandler: regression guard now asserts `Period.Name == "noaction"` and `Status.CurrentPeriod.Name == "noaction"` (was only asserting `SkipRemaining == false`). Removed a non-test that accepted any result.

## Commits

- `215f99e` — Patch finalizers + invalidate auth cache (Critical)
- `bcbe101` — Deterministic auth & controller tests (Important)
- `48f9e49` — Active→noaction regression guard (Important)
- `9d34e44` — Follow-up review fixes (NotFound handling, cache extraction, dead-code removal, nil-factory panic, deeper tests)

## Test plan

- [x] `make test` — handlers coverage **86.0 %** (was 84.1 %), gcp controller coverage 58.3 %
- [x] `go test -race ./internal/controller/gcp/service/handlers/...` clean (20 concurrent workers, no data races)
- [x] `make lint` — zero net-new issues on touched files
- [x] New deterministic tests pass: cache hit on unchanged ResourceVersion, rebuild on rotated ResourceVersion with observable Close, NotFound reconcile, NotFound mid-patch, retry-on-conflict on both patches, active→noaction transition, DeepCopy isolation, nil-factory panic
- [ ] Verify in a real cluster: finalizer add/remove on deletion, secret rotation propagation (exactly-once Close observable), no connection leaks over multiple reconciles

## Relation to PR #256

This PR is the GCP counterpart of the k8s hardening in #256. The two PRs don't conflict (disjoint packages) and can be merged independently. The follow-up commit (`9d34e44`) applies the same pattern of fixes as PR #258's follow-up and PR #256's follow-up, so all three controllers now share a consistent shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
