### PR TITLE
fix(flow): classify config errors, reflect them on status, harden finalizer + child names

### DIFF
--- a/api/v1alpha3/flow_types.go
+++ b/api/v1alpha3/flow_types.go
@@ -42,6 +42,10 @@ type Resources struct {
 
 // K8sResource defines a Kubernetes resource configuration in a flow.
 type K8sResource struct {
+	// Name is used both as an identifier inside the Flow spec and as a component of the
+	// generated child K8s CR name. It must be a DNS-1123 label.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	Name      string           `json:"name"`
 	Resources common.Resources `json:"resources"`
 	Config    K8sConfig        `json:"config,omitempty"`
@@ -49,6 +53,10 @@ type K8sResource struct {
 
 // GcpResource defines a GCP resource configuration in a flow.
 type GcpResource struct {
+	// Name is used both as an identifier inside the Flow spec and as a component of the
+	// generated child Gcp CR name. It must be a DNS-1123 label.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	Name      string           `json:"name"`
 	Resources common.Resources `json:"resources"`
 	Config    GcpConfig        `json:"config,omitempty"`
@@ -62,6 +70,10 @@ type Flows struct {
 
 // FlowResource defines a resource within a flow.
 type FlowResource struct {
+	// Name must match a K8sResource or GcpResource declared in spec.resources. Constrained
+	// to DNS-1123 label syntax to keep generated child CR names valid.
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`
+	// +kubebuilder:validation:MaxLength=63
 	Name string `json:"name"`
 
 	// StartTimeDelay is the duration to delay the start of the period

--- a/config/crd/bases/kubecloudscaler.cloud_flows.yaml
+++ b/config/crd/bases/kubecloudscaler.cloud_flows.yaml
@@ -59,6 +59,11 @@ spec:
                             pattern: ^\d*m$
                             type: string
                           name:
+                            description: |-
+                              Name must match a K8sResource or GcpResource declared in spec.resources. Constrained
+                              to DNS-1123 label syntax to keep generated child CR names valid.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           startTimeDelay:
                             default: 0m
@@ -218,6 +223,11 @@ spec:
                           - restoreOnDelete
                           type: object
                         name:
+                          description: |-
+                            Name is used both as an identifier inside the Flow spec and as a component of the
+                            generated child Gcp CR name. It must be a DNS-1123 label.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resources:
                           description: Resources defines the configuration for managed
@@ -333,6 +343,11 @@ spec:
                           - restoreOnDelete
                           type: object
                         name:
+                          description: |-
+                            Name is used both as an identifier inside the Flow spec and as a component of the
+                            generated child K8s CR name. It must be a DNS-1123 label.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resources:
                           description: Resources defines the configuration for managed

--- a/helm/templates/flow-crd.yaml
+++ b/helm/templates/flow-crd.yaml
@@ -59,6 +59,11 @@ spec:
                             pattern: ^\d*m$
                             type: string
                           name:
+                            description: |-
+                              Name must match a K8sResource or GcpResource declared in spec.resources. Constrained
+                              to DNS-1123 label syntax to keep generated child CR names valid.
+                            maxLength: 63
+                            pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                             type: string
                           startTimeDelay:
                             default: 0m
@@ -218,6 +223,11 @@ spec:
                           - restoreOnDelete
                           type: object
                         name:
+                          description: |-
+                            Name is used both as an identifier inside the Flow spec and as a component of the
+                            generated child Gcp CR name. It must be a DNS-1123 label.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resources:
                           description: Resources defines the configuration for managed
@@ -333,6 +343,11 @@ spec:
                           - restoreOnDelete
                           type: object
                         name:
+                          description: |-
+                            Name is used both as an identifier inside the Flow spec and as a component of the
+                            generated child K8s CR name. It must be a DNS-1123 label.
+                          maxLength: 63
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resources:
                           description: Resources defines the configuration for managed

--- a/internal/controller/flow/CLAUDE.md
+++ b/internal/controller/flow/CLAUDE.md
@@ -12,25 +12,36 @@ FetchHandler -> FinalizerHandler -> ProcessingHandler -> StatusHandler
 ```
 
 - **FetchHandler** - Loads the Flow from the API server
-- **FinalizerHandler** - Adds/removes `kubecloudscaler.cloud/flow-finalizer` via optimistic-locked Patch
-- **ProcessingHandler** - Delegates to the `FlowProcessor` service. Populates
-  `ctx.Condition` (success or failure) and `ctx.ProcessingError`, never short-circuits so
-  StatusHandler can still persist the outcome. The controller classifies
-  ProcessingError as CriticalError (ValidationError) or RecoverableError afterwards.
+- **FinalizerHandler** - Adds/removes `kubecloudscaler.cloud/flow-finalizer` via
+  optimistic-locked Patch. NotFound is treated as a no-op (the Flow was deleted between
+  Fetch and Patch); on success `ctx.Flow` is refreshed so later handlers see the current
+  ResourceVersion.
+- **ProcessingHandler** - Delegates to the `FlowProcessor` service. Always populates
+  `ctx.Condition` (success or failure); populates `ctx.ProcessingError` only on failure.
+  Never short-circuits so StatusHandler can still persist the outcome. The controller then
+  classifies `ctx.ProcessingError` as CriticalError (ValidationError) or RecoverableError
+  independently of the chain's returned error — StatusHandler failing to persist must not
+  downgrade a ValidationError to a hot-requeuing RecoverableError.
 - **StatusHandler** - Writes the condition from `ctx.Condition` (falls back to a default
-  success) via the `StatusUpdater` service.
+  success when the chain ended before ProcessingHandler). Arms the success requeue
+  (`ReconcileSuccessDuration`) only when processing actually succeeded; transient
+  processing failures fall through to the controller's `ReconcileErrorDuration` default.
 
 Injected services:
 
 - **FlowProcessor** - Core workflow processing (validate → map → create)
 - **FlowValidator** - Validates flow configuration; returns `*ValidationError` for
-  user-config mistakes (unknown period, invalid delay, inverted window, …)
+  user-config mistakes. See `service/errors.go` for the full closed set of reason
+  constants.
 - **ResourceCreator** - Creates child K8s/Gcp resources; builds deterministic
   collision-safe names via `childResourceName`
 - **ResourceMapper** - Maps flow definitions to resource specs; `*ValidationError` for
   ambiguous / unknown / duplicate resources
 - **StatusUpdater** - Writes conditions to Flow status with retry-on-conflict
-- **TimeCalculator** - Computes timing delays; recurring periods are allowed to cross midnight
+- **TimeCalculator** - Computes timing delays. Recurring periods are allowed to cross
+  midnight for duration math; zero-duration periods (start == end) are rejected. Note:
+  `pkg/period` currently refuses cross-midnight recurring windows at activation time, so
+  a 22:00→02:00 Flow will pass validation but fail activation until pkg/period is aligned.
 
 ## Key Patterns
 

--- a/internal/controller/flow/CLAUDE.md
+++ b/internal/controller/flow/CLAUDE.md
@@ -4,14 +4,33 @@ Orchestrates multi-resource scaling workflows across K8s and GCP resources.
 
 ## Architecture
 
-The Flow controller uses a service-based pattern (not the handler chain):
+Same Chain of Responsibility pattern as the k8s/gcp controllers. One handler per
+reconciliation step; services are injected into handlers for the business logic.
 
-- **FlowProcessor** - Core workflow processing
-- **FlowValidator** - Validates flow configuration
-- **ResourceCreator** - Creates child K8s/Gcp resources
-- **ResourceMapper** - Maps flow definitions to resource specs
-- **StatusUpdater** - Aggregates status from child resources
-- **TimeCalculator** - Computes timing delays for cascade scaling
+```
+FetchHandler -> FinalizerHandler -> ProcessingHandler -> StatusHandler
+```
+
+- **FetchHandler** - Loads the Flow from the API server
+- **FinalizerHandler** - Adds/removes `kubecloudscaler.cloud/flow-finalizer` via optimistic-locked Patch
+- **ProcessingHandler** - Delegates to the `FlowProcessor` service. Populates
+  `ctx.Condition` (success or failure) and `ctx.ProcessingError`, never short-circuits so
+  StatusHandler can still persist the outcome. The controller classifies
+  ProcessingError as CriticalError (ValidationError) or RecoverableError afterwards.
+- **StatusHandler** - Writes the condition from `ctx.Condition` (falls back to a default
+  success) via the `StatusUpdater` service.
+
+Injected services:
+
+- **FlowProcessor** - Core workflow processing (validate → map → create)
+- **FlowValidator** - Validates flow configuration; returns `*ValidationError` for
+  user-config mistakes (unknown period, invalid delay, inverted window, …)
+- **ResourceCreator** - Creates child K8s/Gcp resources; builds deterministic
+  collision-safe names via `childResourceName`
+- **ResourceMapper** - Maps flow definitions to resource specs; `*ValidationError` for
+  ambiguous / unknown / duplicate resources
+- **StatusUpdater** - Writes conditions to Flow status with retry-on-conflict
+- **TimeCalculator** - Computes timing delays; recurring periods are allowed to cross midnight
 
 ## Key Patterns
 

--- a/internal/controller/flow/flow_controller.go
+++ b/internal/controller/flow/flow_controller.go
@@ -121,6 +121,16 @@ func (r *FlowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	err := r.chain.Execute(reconCtx)
 	duration := time.Since(start).Seconds()
 
+	// If the chain completed but ProcessingHandler recorded a processing failure, classify
+	// it here. StatusHandler has already persisted the failure condition on the Flow.
+	if err == nil && reconCtx.ProcessingError != nil {
+		if service.IsValidationError(reconCtx.ProcessingError) {
+			err = shared.NewCriticalError(reconCtx.ProcessingError)
+		} else {
+			err = shared.NewRecoverableError(reconCtx.ProcessingError)
+		}
+	}
+
 	if err != nil {
 		if shared.IsCriticalError(err) {
 			rec.RecordReconcile(metrics.ControllerFlow, metrics.ResultCriticalError, duration)

--- a/internal/controller/flow/flow_controller.go
+++ b/internal/controller/flow/flow_controller.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -118,17 +119,22 @@ func (r *FlowReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 		}
 	})
 
-	err := r.chain.Execute(reconCtx)
+	chainErr := r.chain.Execute(reconCtx)
 	duration := time.Since(start).Seconds()
 
-	// If the chain completed but ProcessingHandler recorded a processing failure, classify
-	// it here. StatusHandler has already persisted the failure condition on the Flow.
-	if err == nil && reconCtx.ProcessingError != nil {
-		if service.IsValidationError(reconCtx.ProcessingError) {
-			err = shared.NewCriticalError(reconCtx.ProcessingError)
-		} else {
-			err = shared.NewRecoverableError(reconCtx.ProcessingError)
-		}
+	// ProcessingError classification dominates the chain's returned error: a user-config
+	// ValidationError must surface as Critical (no requeue) even when StatusHandler itself
+	// failed to persist the condition, otherwise the controller would hot-loop on a spec it
+	// knows is broken. When both errors are present we aggregate via errors.Join so neither
+	// is lost for logging; classification is driven by ProcessingError.
+	var err error
+	switch {
+	case reconCtx.ProcessingError != nil && service.IsValidationError(reconCtx.ProcessingError):
+		err = shared.NewCriticalError(errors.Join(reconCtx.ProcessingError, chainErr))
+	case reconCtx.ProcessingError != nil:
+		err = shared.NewRecoverableError(errors.Join(reconCtx.ProcessingError, chainErr))
+	default:
+		err = chainErr
 	}
 
 	if err != nil {

--- a/internal/controller/flow/service/errors.go
+++ b/internal/controller/flow/service/errors.go
@@ -16,7 +16,12 @@ limitations under the License.
 
 package service
 
-import "github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
+import (
+	"errors"
+	"fmt"
+
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
+)
 
 // Type aliases for backward compatibility — all error logic lives in shared package.
 type CriticalError = shared.CriticalError
@@ -28,3 +33,40 @@ var (
 	IsCriticalError     = shared.IsCriticalError
 	IsRecoverableError  = shared.IsRecoverableError
 )
+
+// ValidationError marks a user-config error that will not be resolved by a retry. The Flow
+// controller surfaces these as Kubernetes conditions with a specific Reason and classifies
+// them as CriticalError so the reconcile does not hot-loop on a broken spec.
+type ValidationError struct {
+	Reason string
+	Err    error
+}
+
+// NewValidationError wraps err as a validation error with the given short Reason. The Reason
+// becomes the condition Reason on the Flow status.
+func NewValidationError(reason string, err error) error {
+	return &ValidationError{Reason: reason, Err: err}
+}
+
+func (e *ValidationError) Error() string {
+	return fmt.Sprintf("%s: %v", e.Reason, e.Err)
+}
+
+func (e *ValidationError) Unwrap() error {
+	return e.Err
+}
+
+// IsValidationError reports whether err is (wraps) a *ValidationError.
+func IsValidationError(err error) bool {
+	var v *ValidationError
+	return errors.As(err, &v)
+}
+
+// AsValidationError returns the innermost *ValidationError when err wraps one.
+func AsValidationError(err error) (*ValidationError, bool) {
+	var v *ValidationError
+	if errors.As(err, &v) {
+		return v, true
+	}
+	return nil, false
+}

--- a/internal/controller/flow/service/errors.go
+++ b/internal/controller/flow/service/errors.go
@@ -34,17 +34,41 @@ var (
 	IsRecoverableError  = shared.IsRecoverableError
 )
 
+// ValidationReason is the closed set of reasons carried by a ValidationError. Values flow
+// through to Flow.status as condition Reason strings, so they are a public contract and
+// must remain stable — rename with care.
+type ValidationReason string
+
+const (
+	ReasonUnknownPeriod             ValidationReason = "UnknownPeriod"
+	ReasonInvalidPeriodDuration     ValidationReason = "InvalidPeriodDuration"
+	ReasonZeroPeriodDuration        ValidationReason = "ZeroPeriodDuration"
+	ReasonInvalidDelayFormat        ValidationReason = "InvalidDelayFormat"
+	ReasonInvertedWindow            ValidationReason = "InvertedWindow"
+	ReasonDuplicatePeriod           ValidationReason = "DuplicatePeriod"
+	ReasonDuplicateResource         ValidationReason = "DuplicateResource"
+	ReasonDuplicateResourceInPeriod ValidationReason = "DuplicateResourceInPeriod"
+	ReasonAmbiguousResource         ValidationReason = "AmbiguousResource"
+	ReasonUnknownResource           ValidationReason = "UnknownResource"
+	ReasonUnknownResourceType       ValidationReason = "UnknownResourceType"
+	ReasonMissingK8sResource        ValidationReason = "MissingK8sResource"
+	ReasonMissingGcpResource        ValidationReason = "MissingGcpResource"
+	// ReasonProcessingFailed is the fallback reason for non-validation errors that surface
+	// on Flow.status. Kept here so the full set of condition reasons lives in one place.
+	ReasonProcessingFailed ValidationReason = "ProcessingFailed"
+)
+
 // ValidationError marks a user-config error that will not be resolved by a retry. The Flow
 // controller surfaces these as Kubernetes conditions with a specific Reason and classifies
 // them as CriticalError so the reconcile does not hot-loop on a broken spec.
 type ValidationError struct {
-	Reason string
+	Reason ValidationReason
 	Err    error
 }
 
-// NewValidationError wraps err as a validation error with the given short Reason. The Reason
+// NewValidationError wraps err as a validation error with the given Reason. The Reason
 // becomes the condition Reason on the Flow status.
-func NewValidationError(reason string, err error) error {
+func NewValidationError(reason ValidationReason, err error) error {
 	return &ValidationError{Reason: reason, Err: err}
 }
 
@@ -62,7 +86,7 @@ func IsValidationError(err error) bool {
 	return errors.As(err, &v)
 }
 
-// AsValidationError returns the innermost *ValidationError when err wraps one.
+// AsValidationError returns the first *ValidationError found while unwrapping err.
 func AsValidationError(err error) (*ValidationError, bool) {
 	var v *ValidationError
 	if errors.As(err, &v) {

--- a/internal/controller/flow/service/flow_context.go
+++ b/internal/controller/flow/service/flow_context.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -56,6 +57,19 @@ type FlowReconciliationContext struct {
 	// Flow is the resource being reconciled.
 	// Set by: FetchHandler
 	Flow *kubecloudscalerv1alpha3.Flow
+
+	// Condition is the Processed condition to persist on the Flow status.
+	// Set by: ProcessingHandler (success or failure)
+	// Used by: StatusHandler
+	Condition *metav1.Condition
+
+	// ProcessingError carries the error produced by ProcessFlow, if any. The processing
+	// handler stores it here and lets the chain continue so StatusHandler can still write
+	// the failure condition. The controller reads this after the chain to classify and
+	// return the appropriate requeue behavior.
+	// Set by: ProcessingHandler
+	// Used by: Controller (Reconcile)
+	ProcessingError error
 
 	// SkipRemaining stops the chain early (e.g., during deletion cleanup).
 	// Set by: Any handler (e.g., FinalizerHandler on deletion)

--- a/internal/controller/flow/service/flow_processor.go
+++ b/internal/controller/flow/service/flow_processor.go
@@ -96,18 +96,18 @@ func (s *FlowProcessorService) processResource(
 	switch resourceInfo.Type {
 	case "k8s":
 		if resourceInfo.K8sRes == nil {
-			return NewValidationError("MissingK8sResource",
+			return NewValidationError(ReasonMissingK8sResource,
 				fmt.Errorf("K8sRes is nil for resource %s", resourceName))
 		}
 		return s.resourceCreator.CreateK8sResource(ctx, flow, resourceName, *resourceInfo.K8sRes, resourceInfo.Periods)
 	case "gcp":
 		if resourceInfo.GcpRes == nil {
-			return NewValidationError("MissingGcpResource",
+			return NewValidationError(ReasonMissingGcpResource,
 				fmt.Errorf("GcpRes is nil for resource %s", resourceName))
 		}
 		return s.resourceCreator.CreateGcpResource(ctx, flow, resourceName, *resourceInfo.GcpRes, resourceInfo.Periods)
 	default:
-		return NewValidationError("UnknownResourceType",
+		return NewValidationError(ReasonUnknownResourceType,
 			fmt.Errorf("unknown resource type: %s", resourceInfo.Type))
 	}
 }

--- a/internal/controller/flow/service/flow_processor.go
+++ b/internal/controller/flow/service/flow_processor.go
@@ -96,15 +96,18 @@ func (s *FlowProcessorService) processResource(
 	switch resourceInfo.Type {
 	case "k8s":
 		if resourceInfo.K8sRes == nil {
-			return fmt.Errorf("K8sRes is nil for resource %s", resourceName)
+			return NewValidationError("MissingK8sResource",
+				fmt.Errorf("K8sRes is nil for resource %s", resourceName))
 		}
 		return s.resourceCreator.CreateK8sResource(ctx, flow, resourceName, *resourceInfo.K8sRes, resourceInfo.Periods)
 	case "gcp":
 		if resourceInfo.GcpRes == nil {
-			return fmt.Errorf("GcpRes is nil for resource %s", resourceName)
+			return NewValidationError("MissingGcpResource",
+				fmt.Errorf("GcpRes is nil for resource %s", resourceName))
 		}
 		return s.resourceCreator.CreateGcpResource(ctx, flow, resourceName, *resourceInfo.GcpRes, resourceInfo.Periods)
 	default:
-		return fmt.Errorf("unknown resource type: %s", resourceInfo.Type)
+		return NewValidationError("UnknownResourceType",
+			fmt.Errorf("unknown resource type: %s", resourceInfo.Type))
 	}
 }

--- a/internal/controller/flow/service/flow_processor_simple_test.go
+++ b/internal/controller/flow/service/flow_processor_simple_test.go
@@ -114,5 +114,32 @@ var _ = Describe("FlowProcessorService", func() {
 				Expect(err.Error()).To(ContainSubstring("failed to extract flow data"))
 			})
 		})
+
+		DescribeTable("emits the expected ValidationError when resource info is structurally wrong",
+			func(info types.ResourceInfo, expected ValidationReason) {
+				flow := &kubecloudscalerv1alpha3.Flow{}
+
+				mockValidator.ExtractFlowDataFunc = func(
+					_ *kubecloudscalerv1alpha3.Flow,
+				) (map[string]bool, map[string]bool, error) {
+					return map[string]bool{"r": true}, map[string]bool{}, nil
+				}
+				mockResourceMapper.CreateResourceMappingsFunc = func(
+					_ *kubecloudscalerv1alpha3.Flow, _ map[string]bool,
+				) (map[string]types.ResourceInfo, error) {
+					return map[string]types.ResourceInfo{"r": info}, nil
+				}
+
+				err := svc.ProcessFlow(context.Background(), flow)
+
+				Expect(err).To(HaveOccurred())
+				v, ok := AsValidationError(err)
+				Expect(ok).To(BeTrue(), "expected a ValidationError, got %T: %v", err, err)
+				Expect(v.Reason).To(Equal(expected))
+			},
+			Entry("k8s with nil K8sRes", types.ResourceInfo{Type: "k8s"}, ReasonMissingK8sResource),
+			Entry("gcp with nil GcpRes", types.ResourceInfo{Type: "gcp"}, ReasonMissingGcpResource),
+			Entry("unknown type", types.ResourceInfo{Type: "wat"}, ReasonUnknownResourceType),
+		)
 	})
 })

--- a/internal/controller/flow/service/flow_validator.go
+++ b/internal/controller/flow/service/flow_validator.go
@@ -39,8 +39,18 @@ func NewFlowValidatorService(timeCalculator TimeCalculator, logger *zerolog.Logg
 	}
 }
 
-// ExtractFlowData extracts all resource names and period names from flows
+// ExtractFlowData extracts all resource names and period names from flows. Duplicate
+// period definitions (same name twice in spec.periods) and in-section duplicate resource
+// definitions (same name twice in spec.resources.k8s or spec.resources.gcp) are rejected
+// here since silent first-writer-wins would produce unpredictable runtime behaviour.
 func (v *FlowValidatorService) ExtractFlowData(flow *kubecloudscalerv1alpha3.Flow) (map[string]bool, map[string]bool, error) {
+	if err := v.checkUniquePeriods(flow); err != nil {
+		return nil, nil, err
+	}
+	if err := v.checkUniqueResources(flow); err != nil {
+		return nil, nil, err
+	}
+
 	resourceNames := make(map[string]bool)
 	periodNames := make(map[string]bool)
 
@@ -55,22 +65,61 @@ func (v *FlowValidatorService) ExtractFlowData(flow *kubecloudscalerv1alpha3.Flo
 	return resourceNames, periodNames, nil
 }
 
-// ValidatePeriodTimings validates that the sum of delays for each period doesn't exceed the period duration.
-// User-config errors (unknown period reference, invalid delay format, inverted window) are returned as
-// *ValidationError so ProcessingHandler can classify them as CriticalError.
+func (v *FlowValidatorService) checkUniquePeriods(flow *kubecloudscalerv1alpha3.Flow) error {
+	seen := make(map[string]bool, len(flow.Spec.Periods))
+	for i := range flow.Spec.Periods {
+		name := flow.Spec.Periods[i].Name
+		if seen[name] {
+			return NewValidationError(ReasonDuplicatePeriod,
+				fmt.Errorf("period %s defined more than once in spec.periods", name))
+		}
+		seen[name] = true
+	}
+	return nil
+}
+
+func (v *FlowValidatorService) checkUniqueResources(flow *kubecloudscalerv1alpha3.Flow) error {
+	seenK8s := make(map[string]bool, len(flow.Spec.Resources.K8s))
+	for i := range flow.Spec.Resources.K8s {
+		name := flow.Spec.Resources.K8s[i].Name
+		if seenK8s[name] {
+			return NewValidationError(ReasonDuplicateResource,
+				fmt.Errorf("resource %s defined more than once in spec.resources.k8s", name))
+		}
+		seenK8s[name] = true
+	}
+	seenGcp := make(map[string]bool, len(flow.Spec.Resources.Gcp))
+	for i := range flow.Spec.Resources.Gcp {
+		name := flow.Spec.Resources.Gcp[i].Name
+		if seenGcp[name] {
+			return NewValidationError(ReasonDuplicateResource,
+				fmt.Errorf("resource %s defined more than once in spec.resources.gcp", name))
+		}
+		seenGcp[name] = true
+	}
+	return nil
+}
+
+// ValidatePeriodTimings validates that the sum of delays for each period doesn't exceed
+// the period duration. User-config errors are returned as *ValidationError so
+// ProcessingHandler can classify them as CriticalError. See the ReasonXxx constants in
+// errors.go for the full set of reasons this can emit.
 func (v *FlowValidatorService) ValidatePeriodTimings(flow *kubecloudscalerv1alpha3.Flow, periodNames map[string]bool) error {
 	periodsMap := v.createPeriodsMap(flow)
 
 	for periodName := range periodNames {
 		period, exists := periodsMap[periodName]
 		if !exists {
-			return NewValidationError("UnknownPeriod",
+			return NewValidationError(ReasonUnknownPeriod,
 				fmt.Errorf("period %s referenced in flows but not defined", periodName))
 		}
 
 		periodDuration, err := v.timeCalculator.GetPeriodDuration(&period)
 		if err != nil {
-			return NewValidationError("InvalidPeriodDuration",
+			if IsValidationError(err) {
+				return err
+			}
+			return NewValidationError(ReasonInvalidPeriodDuration,
 				fmt.Errorf("failed to get period duration for %s: %w", periodName, err))
 		}
 
@@ -105,7 +154,7 @@ func (v *FlowValidatorService) validateResourceDelays(flow *kubecloudscalerv1alp
 			if resource.StartTimeDelay != "" {
 				d, err := time.ParseDuration(resource.StartTimeDelay)
 				if err != nil {
-					return NewValidationError("InvalidDelayFormat",
+					return NewValidationError(ReasonInvalidDelayFormat,
 						fmt.Errorf("invalid start time delay format for resource %s: %w", resource.Name, err))
 				}
 				startDelay = d
@@ -114,7 +163,7 @@ func (v *FlowValidatorService) validateResourceDelays(flow *kubecloudscalerv1alp
 			if resource.EndTimeDelay != "" {
 				d, err := time.ParseDuration(resource.EndTimeDelay)
 				if err != nil {
-					return NewValidationError("InvalidDelayFormat",
+					return NewValidationError(ReasonInvalidDelayFormat,
 						fmt.Errorf("invalid end time delay format for resource %s: %w", resource.Name, err))
 				}
 				endDelay = d
@@ -125,7 +174,7 @@ func (v *FlowValidatorService) validateResourceDelays(flow *kubecloudscalerv1alp
 			// Must be > 0 for the window to remain valid
 			adjustedDuration := periodDuration - startDelay + endDelay
 			if adjustedDuration <= 0 {
-				return NewValidationError("InvertedWindow", fmt.Errorf(
+				return NewValidationError(ReasonInvertedWindow, fmt.Errorf(
 					"resource %s: adjusted window is invalid (duration %v) for period %s — "+
 						"startTimeDelay (%v) and endTimeDelay (%v) invert the period window (duration %v)",
 					resource.Name, adjustedDuration, periodName,

--- a/internal/controller/flow/service/flow_validator.go
+++ b/internal/controller/flow/service/flow_validator.go
@@ -55,19 +55,23 @@ func (v *FlowValidatorService) ExtractFlowData(flow *kubecloudscalerv1alpha3.Flo
 	return resourceNames, periodNames, nil
 }
 
-// ValidatePeriodTimings validates that the sum of delays for each period doesn't exceed the period duration
+// ValidatePeriodTimings validates that the sum of delays for each period doesn't exceed the period duration.
+// User-config errors (unknown period reference, invalid delay format, inverted window) are returned as
+// *ValidationError so ProcessingHandler can classify them as CriticalError.
 func (v *FlowValidatorService) ValidatePeriodTimings(flow *kubecloudscalerv1alpha3.Flow, periodNames map[string]bool) error {
 	periodsMap := v.createPeriodsMap(flow)
 
 	for periodName := range periodNames {
 		period, exists := periodsMap[periodName]
 		if !exists {
-			return fmt.Errorf("period %s referenced in flows but not defined", periodName)
+			return NewValidationError("UnknownPeriod",
+				fmt.Errorf("period %s referenced in flows but not defined", periodName))
 		}
 
 		periodDuration, err := v.timeCalculator.GetPeriodDuration(&period)
 		if err != nil {
-			return fmt.Errorf("failed to get period duration for %s: %w", periodName, err)
+			return NewValidationError("InvalidPeriodDuration",
+				fmt.Errorf("failed to get period duration for %s: %w", periodName, err))
 		}
 
 		if err := v.validateResourceDelays(flow, periodName, periodDuration); err != nil {
@@ -101,7 +105,8 @@ func (v *FlowValidatorService) validateResourceDelays(flow *kubecloudscalerv1alp
 			if resource.StartTimeDelay != "" {
 				d, err := time.ParseDuration(resource.StartTimeDelay)
 				if err != nil {
-					return fmt.Errorf("invalid start time delay format for resource %s: %w", resource.Name, err)
+					return NewValidationError("InvalidDelayFormat",
+						fmt.Errorf("invalid start time delay format for resource %s: %w", resource.Name, err))
 				}
 				startDelay = d
 			}
@@ -109,7 +114,8 @@ func (v *FlowValidatorService) validateResourceDelays(flow *kubecloudscalerv1alp
 			if resource.EndTimeDelay != "" {
 				d, err := time.ParseDuration(resource.EndTimeDelay)
 				if err != nil {
-					return fmt.Errorf("invalid end time delay format for resource %s: %w", resource.Name, err)
+					return NewValidationError("InvalidDelayFormat",
+						fmt.Errorf("invalid end time delay format for resource %s: %w", resource.Name, err))
 				}
 				endDelay = d
 			}
@@ -119,12 +125,12 @@ func (v *FlowValidatorService) validateResourceDelays(flow *kubecloudscalerv1alp
 			// Must be > 0 for the window to remain valid
 			adjustedDuration := periodDuration - startDelay + endDelay
 			if adjustedDuration <= 0 {
-				return fmt.Errorf(
+				return NewValidationError("InvertedWindow", fmt.Errorf(
 					"resource %s: adjusted window is invalid (duration %v) for period %s — "+
 						"startTimeDelay (%v) and endTimeDelay (%v) invert the period window (duration %v)",
 					resource.Name, adjustedDuration, periodName,
 					startDelay, endDelay, periodDuration,
-				)
+				))
 			}
 		}
 	}

--- a/internal/controller/flow/service/flow_validator_test.go
+++ b/internal/controller/flow/service/flow_validator_test.go
@@ -51,7 +51,7 @@ var _ = Describe("FlowValidatorService.ValidatePeriodTimings", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(service.IsValidationError(err)).To(BeTrue())
 		v, _ := service.AsValidationError(err)
-		Expect(v.Reason).To(Equal("UnknownPeriod"))
+		Expect(v.Reason).To(Equal(service.ReasonUnknownPeriod))
 	})
 
 	It("returns a ValidationError for an invalid delay format", func() {
@@ -78,7 +78,7 @@ var _ = Describe("FlowValidatorService.ValidatePeriodTimings", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(service.IsValidationError(err)).To(BeTrue())
 		v, _ := service.AsValidationError(err)
-		Expect(v.Reason).To(Equal("InvalidDelayFormat"))
+		Expect(v.Reason).To(Equal(service.ReasonInvalidDelayFormat))
 	})
 
 	It("returns a ValidationError when delays invert the window", func() {
@@ -106,7 +106,7 @@ var _ = Describe("FlowValidatorService.ValidatePeriodTimings", func() {
 		Expect(err).To(HaveOccurred())
 		v, ok := service.AsValidationError(err)
 		Expect(ok).To(BeTrue())
-		Expect(v.Reason).To(Equal("InvertedWindow"))
+		Expect(v.Reason).To(Equal(service.ReasonInvertedWindow))
 	})
 
 	It("returns nil for a valid flow with compatible delays", func() {

--- a/internal/controller/flow/service/flow_validator_test.go
+++ b/internal/controller/flow/service/flow_validator_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+
+	"github.com/kubecloudscaler/kubecloudscaler/api/common"
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
+)
+
+func newFlowWithPeriods(periods ...common.ScalerPeriod) *kubecloudscalerv1alpha3.Flow {
+	return &kubecloudscalerv1alpha3.Flow{
+		Spec: kubecloudscalerv1alpha3.FlowSpec{Periods: periods},
+	}
+}
+
+var _ = Describe("FlowValidatorService.ValidatePeriodTimings", func() {
+	var (
+		logger zerolog.Logger
+		svc    service.FlowValidator
+	)
+
+	BeforeEach(func() {
+		logger = zerolog.Nop()
+		tc := service.NewTimeCalculatorService(&logger)
+		svc = service.NewFlowValidatorService(tc, &logger)
+	})
+
+	It("returns a ValidationError when a referenced period is not defined", func() {
+		flow := newFlowWithPeriods() // no periods
+		err := svc.ValidatePeriodTimings(flow, map[string]bool{"missing": true})
+
+		Expect(err).To(HaveOccurred())
+		Expect(service.IsValidationError(err)).To(BeTrue())
+		v, _ := service.AsValidationError(err)
+		Expect(v.Reason).To(Equal("UnknownPeriod"))
+	})
+
+	It("returns a ValidationError for an invalid delay format", func() {
+		period := common.ScalerPeriod{
+			Name: "biz",
+			Type: common.PeriodTypeUp,
+			Time: common.TimePeriod{Recurring: &common.RecurringPeriod{
+				StartTime: "09:00", EndTime: "17:00",
+				Days: []common.DayOfWeek{common.DayAll},
+			}},
+		}
+		flow := newFlowWithPeriods(period)
+		flow.Spec.Flows = []kubecloudscalerv1alpha3.Flows{
+			{
+				PeriodName: "biz",
+				Resources: []kubecloudscalerv1alpha3.FlowResource{
+					{Name: "api", StartTimeDelay: "not-a-duration"},
+				},
+			},
+		}
+
+		err := svc.ValidatePeriodTimings(flow, map[string]bool{"biz": true})
+
+		Expect(err).To(HaveOccurred())
+		Expect(service.IsValidationError(err)).To(BeTrue())
+		v, _ := service.AsValidationError(err)
+		Expect(v.Reason).To(Equal("InvalidDelayFormat"))
+	})
+
+	It("returns a ValidationError when delays invert the window", func() {
+		// 1h period, startDelay=2h → adjustedDuration <= 0
+		period := common.ScalerPeriod{
+			Name: "short",
+			Type: common.PeriodTypeUp,
+			Time: common.TimePeriod{Recurring: &common.RecurringPeriod{
+				StartTime: "09:00", EndTime: "10:00",
+				Days: []common.DayOfWeek{common.DayAll},
+			}},
+		}
+		flow := newFlowWithPeriods(period)
+		flow.Spec.Flows = []kubecloudscalerv1alpha3.Flows{
+			{
+				PeriodName: "short",
+				Resources: []kubecloudscalerv1alpha3.FlowResource{
+					{Name: "api", StartTimeDelay: "2h"},
+				},
+			},
+		}
+
+		err := svc.ValidatePeriodTimings(flow, map[string]bool{"short": true})
+
+		Expect(err).To(HaveOccurred())
+		v, ok := service.AsValidationError(err)
+		Expect(ok).To(BeTrue())
+		Expect(v.Reason).To(Equal("InvertedWindow"))
+	})
+
+	It("returns nil for a valid flow with compatible delays", func() {
+		period := common.ScalerPeriod{
+			Name: "biz",
+			Type: common.PeriodTypeUp,
+			Time: common.TimePeriod{Recurring: &common.RecurringPeriod{
+				StartTime: "09:00", EndTime: "17:00",
+				Days: []common.DayOfWeek{common.DayAll},
+			}},
+		}
+		flow := newFlowWithPeriods(period)
+		flow.Spec.Flows = []kubecloudscalerv1alpha3.Flows{
+			{
+				PeriodName: "biz",
+				Resources: []kubecloudscalerv1alpha3.FlowResource{
+					{Name: "api", StartTimeDelay: "30m", EndTimeDelay: "15m"},
+				},
+			},
+		}
+
+		Expect(svc.ValidatePeriodTimings(flow, map[string]bool{"biz": true})).To(Succeed())
+	})
+})

--- a/internal/controller/flow/service/handlers/fetch_handler.go
+++ b/internal/controller/flow/service/handlers/fetch_handler.go
@@ -17,8 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"fmt"
-
 	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
@@ -26,7 +24,10 @@ import (
 )
 
 // FetchHandler fetches the Flow resource from the Kubernetes API server.
-// Returns CriticalError if the resource is not found (deleted during reconciliation).
+//
+// On success: sets ctx.Flow and continues the chain.
+// On NotFound: returns nil — the Flow was deleted; reconcile has nothing to do (no error log).
+// On other errors: returns RecoverableError for requeue.
 type FetchHandler struct {
 	next service.Handler
 }
@@ -40,9 +41,9 @@ func (h *FetchHandler) Execute(ctx *service.FlowReconciliationContext) error {
 	flow := &kubecloudscalerv1alpha3.Flow{}
 	if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, flow); err != nil {
 		if client.IgnoreNotFound(err) == nil {
-			return shared.NewCriticalError(fmt.Errorf("flow not found: %w", err))
+			return nil
 		}
-		return shared.NewRecoverableError(fmt.Errorf("fetch flow: %w", err))
+		return shared.NewRecoverableError(err)
 	}
 
 	ctx.Flow = flow

--- a/internal/controller/flow/service/handlers/fetch_handler_test.go
+++ b/internal/controller/flow/service/handlers/fetch_handler_test.go
@@ -74,13 +74,12 @@ var _ = Describe("FetchHandler", func() {
 	})
 
 	Context("When the Flow resource is not found", func() {
-		It("returns a CriticalError so the controller ignores NotFound without requeue", func() {
+		It("returns nil without chaining (deleted object, nothing to reconcile)", func() {
 			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
 
 			err := handler.Execute(reconCtx)
 
-			Expect(err).To(HaveOccurred())
-			Expect(shared.IsCriticalError(err)).To(BeTrue())
+			Expect(err).To(Succeed())
 			Expect(reconCtx.Flow).To(BeNil())
 		})
 	})

--- a/internal/controller/flow/service/handlers/fetch_handler_test.go
+++ b/internal/controller/flow/service/handlers/fetch_handler_test.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service/handlers"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
+)
+
+var _ = Describe("FetchHandler", func() {
+	var (
+		handler  service.Handler
+		reconCtx *service.FlowReconciliationContext
+		logger   zerolog.Logger
+		scheme   *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		handler = handlers.NewFetchHandler()
+		logger = zerolog.Nop()
+		scheme = runtime.NewScheme()
+		Expect(kubecloudscalerv1alpha3.AddToScheme(scheme)).To(Succeed())
+
+		reconCtx = &service.FlowReconciliationContext{
+			Ctx: context.Background(),
+			Request: ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: "test-flow"},
+			},
+			Logger: &logger,
+		}
+	})
+
+	Context("When the Flow resource exists", func() {
+		It("populates ctx.Flow and continues the chain", func() {
+			flow := &kubecloudscalerv1alpha3.Flow{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-flow"},
+			}
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(flow).Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.Flow).ToNot(BeNil())
+			Expect(reconCtx.Flow.Name).To(Equal("test-flow"))
+		})
+	})
+
+	Context("When the Flow resource is not found", func() {
+		It("returns a CriticalError so the controller ignores NotFound without requeue", func() {
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			err := handler.Execute(reconCtx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(shared.IsCriticalError(err)).To(BeTrue())
+			Expect(reconCtx.Flow).To(BeNil())
+		})
+	})
+
+	Context("When the API Get returns a non-NotFound error", func() {
+		It("returns a RecoverableError to trigger requeue", func() {
+			injected := fmt.Errorf("transient API failure")
+			reconCtx.Client = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+						return injected
+					},
+				}).
+				Build()
+
+			err := handler.Execute(reconCtx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(shared.IsRecoverableError(err)).To(BeTrue())
+		})
+	})
+})

--- a/internal/controller/flow/service/handlers/finalizer_handler.go
+++ b/internal/controller/flow/service/handlers/finalizer_handler.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	"fmt"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -47,11 +48,19 @@ func (h *FinalizerHandler) Execute(ctx *service.FlowReconciliationContext) error
 	if flow.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(flow, flowFinalizer) {
 			ctx.Logger.Info().Msg("adding finalizer")
-			if err := patchAddFlowFinalizer(ctx); err != nil {
+			latest, err := patchAddFlowFinalizer(ctx)
+			switch {
+			case apierrors.IsNotFound(err):
+				// Flow was deleted between FetchHandler and this patch — nothing to do.
+				ctx.SkipRemaining = true
+				return nil
+			case err != nil:
 				ctx.RequeueAfter = shared.TransientRequeueAfter
 				return shared.NewRecoverableError(fmt.Errorf("add finalizer: %w", err))
 			}
-			controllerutil.AddFinalizer(flow, flowFinalizer)
+			// Refresh ctx.Flow so ResourceVersion and finalizers match the persisted state;
+			// downstream handlers that read ctx.Flow (e.g. for Update) must see the latest.
+			ctx.Flow = latest
 		}
 		if h.next != nil && !ctx.SkipRemaining {
 			return h.next.Execute(ctx)
@@ -61,11 +70,19 @@ func (h *FinalizerHandler) Execute(ctx *service.FlowReconciliationContext) error
 
 	if controllerutil.ContainsFinalizer(flow, flowFinalizer) {
 		ctx.Logger.Info().Msg("removing finalizer")
-		if err := patchRemoveFlowFinalizer(ctx); err != nil {
+		latest, err := patchRemoveFlowFinalizer(ctx)
+		switch {
+		case apierrors.IsNotFound(err):
+			// Flow has already been fully deleted — cleanup is done.
+			ctx.SkipRemaining = true
+			return nil
+		case err != nil:
 			ctx.RequeueAfter = shared.TransientRequeueAfter
 			return shared.NewRecoverableError(fmt.Errorf("remove finalizer: %w", err))
 		}
-		controllerutil.RemoveFinalizer(flow, flowFinalizer)
+		if latest != nil {
+			ctx.Flow = latest
+		}
 	}
 	ctx.SkipRemaining = true
 	return nil
@@ -77,10 +94,12 @@ func (h *FinalizerHandler) SetNext(next service.Handler) {
 
 // patchAddFlowFinalizer adds flowFinalizer via an optimistic-locked merge patch, re-fetching
 // and retrying on 409 conflicts. Scoped to metadata.finalizers so neither spec nor status is
-// transmitted. No-op if the finalizer was added concurrently.
-func patchAddFlowFinalizer(ctx *service.FlowReconciliationContext) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &kubecloudscalerv1alpha3.Flow{}
+// transmitted. Returns the latest persisted Flow so callers can refresh their in-memory copy.
+// No-op if the finalizer was already present.
+func patchAddFlowFinalizer(ctx *service.FlowReconciliationContext) (*kubecloudscalerv1alpha3.Flow, error) {
+	latest := &kubecloudscalerv1alpha3.Flow{}
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest = &kubecloudscalerv1alpha3.Flow{}
 		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, latest); err != nil {
 			return err
 		}
@@ -91,21 +110,36 @@ func patchAddFlowFinalizer(ctx *service.FlowReconciliationContext) error {
 		controllerutil.AddFinalizer(latest, flowFinalizer)
 		return ctx.Client.Patch(ctx.Ctx, latest, patch)
 	})
+	if err != nil {
+		return nil, err
+	}
+	return latest, nil
 }
 
 // patchRemoveFlowFinalizer removes flowFinalizer via an optimistic-locked merge patch,
-// re-fetching and retrying on 409 conflicts. No-op if already absent.
-func patchRemoveFlowFinalizer(ctx *service.FlowReconciliationContext) error {
-	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+// re-fetching and retrying on 409 conflicts. Returns the latest persisted Flow when the
+// finalizer was present and has been removed, nil when already absent. No-op if already absent.
+func patchRemoveFlowFinalizer(ctx *service.FlowReconciliationContext) (*kubecloudscalerv1alpha3.Flow, error) {
+	var result *kubecloudscalerv1alpha3.Flow
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		latest := &kubecloudscalerv1alpha3.Flow{}
 		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, latest); err != nil {
 			return err
 		}
 		if !controllerutil.ContainsFinalizer(latest, flowFinalizer) {
+			result = nil
 			return nil
 		}
 		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
 		controllerutil.RemoveFinalizer(latest, flowFinalizer)
-		return ctx.Client.Patch(ctx.Ctx, latest, patch)
+		if err := ctx.Client.Patch(ctx.Ctx, latest, patch); err != nil {
+			return err
+		}
+		result = latest
+		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	return result, nil
 }

--- a/internal/controller/flow/service/handlers/finalizer_handler.go
+++ b/internal/controller/flow/service/handlers/finalizer_handler.go
@@ -19,9 +19,13 @@ package handlers
 import (
 	"fmt"
 
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const flowFinalizer = "kubecloudscaler.cloud/flow-finalizer"
@@ -43,11 +47,11 @@ func (h *FinalizerHandler) Execute(ctx *service.FlowReconciliationContext) error
 	if flow.DeletionTimestamp.IsZero() {
 		if !controllerutil.ContainsFinalizer(flow, flowFinalizer) {
 			ctx.Logger.Info().Msg("adding finalizer")
-			controllerutil.AddFinalizer(flow, flowFinalizer)
-			if err := ctx.Client.Update(ctx.Ctx, flow); err != nil {
+			if err := patchAddFlowFinalizer(ctx); err != nil {
 				ctx.RequeueAfter = shared.TransientRequeueAfter
 				return shared.NewRecoverableError(fmt.Errorf("add finalizer: %w", err))
 			}
+			controllerutil.AddFinalizer(flow, flowFinalizer)
 		}
 		if h.next != nil && !ctx.SkipRemaining {
 			return h.next.Execute(ctx)
@@ -56,13 +60,12 @@ func (h *FinalizerHandler) Execute(ctx *service.FlowReconciliationContext) error
 	}
 
 	if controllerutil.ContainsFinalizer(flow, flowFinalizer) {
-		ctx.Logger.Info().Msg("deleting flow with finalizer")
 		ctx.Logger.Info().Msg("removing finalizer")
-		controllerutil.RemoveFinalizer(flow, flowFinalizer)
-		if err := ctx.Client.Update(ctx.Ctx, flow); err != nil {
+		if err := patchRemoveFlowFinalizer(ctx); err != nil {
 			ctx.RequeueAfter = shared.TransientRequeueAfter
 			return shared.NewRecoverableError(fmt.Errorf("remove finalizer: %w", err))
 		}
+		controllerutil.RemoveFinalizer(flow, flowFinalizer)
 	}
 	ctx.SkipRemaining = true
 	return nil
@@ -70,4 +73,39 @@ func (h *FinalizerHandler) Execute(ctx *service.FlowReconciliationContext) error
 
 func (h *FinalizerHandler) SetNext(next service.Handler) {
 	h.next = next
+}
+
+// patchAddFlowFinalizer adds flowFinalizer via an optimistic-locked merge patch, re-fetching
+// and retrying on 409 conflicts. Scoped to metadata.finalizers so neither spec nor status is
+// transmitted. No-op if the finalizer was added concurrently.
+func patchAddFlowFinalizer(ctx *service.FlowReconciliationContext) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &kubecloudscalerv1alpha3.Flow{}
+		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, latest); err != nil {
+			return err
+		}
+		if controllerutil.ContainsFinalizer(latest, flowFinalizer) {
+			return nil
+		}
+		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		controllerutil.AddFinalizer(latest, flowFinalizer)
+		return ctx.Client.Patch(ctx.Ctx, latest, patch)
+	})
+}
+
+// patchRemoveFlowFinalizer removes flowFinalizer via an optimistic-locked merge patch,
+// re-fetching and retrying on 409 conflicts. No-op if already absent.
+func patchRemoveFlowFinalizer(ctx *service.FlowReconciliationContext) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &kubecloudscalerv1alpha3.Flow{}
+		if err := ctx.Client.Get(ctx.Ctx, ctx.Request.NamespacedName, latest); err != nil {
+			return err
+		}
+		if !controllerutil.ContainsFinalizer(latest, flowFinalizer) {
+			return nil
+		}
+		patch := client.MergeFromWithOptions(latest.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		controllerutil.RemoveFinalizer(latest, flowFinalizer)
+		return ctx.Client.Patch(ctx.Ctx, latest, patch)
+	})
 }

--- a/internal/controller/flow/service/handlers/finalizer_handler_test.go
+++ b/internal/controller/flow/service/handlers/finalizer_handler_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service/handlers"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
+)
+
+const flowFinalizerConst = "kubecloudscaler.cloud/flow-finalizer"
+
+var _ = Describe("FinalizerHandler", func() {
+	var (
+		handler  service.Handler
+		reconCtx *service.FlowReconciliationContext
+		logger   zerolog.Logger
+		scheme   *runtime.Scheme
+		flow     *kubecloudscalerv1alpha3.Flow
+	)
+
+	BeforeEach(func() {
+		handler = handlers.NewFinalizerHandler()
+		logger = zerolog.Nop()
+		scheme = runtime.NewScheme()
+		Expect(kubecloudscalerv1alpha3.AddToScheme(scheme)).To(Succeed())
+
+		flow = &kubecloudscalerv1alpha3.Flow{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-flow"},
+		}
+		reconCtx = &service.FlowReconciliationContext{
+			Ctx: context.Background(),
+			Request: ctrl.Request{
+				NamespacedName: types.NamespacedName{Name: flow.Name},
+			},
+			Logger: &logger,
+			Flow:   flow,
+		}
+	})
+
+	Context("When the flow is not being deleted and has no finalizer", func() {
+		It("persists the finalizer via Patch and updates ctx.Flow", func() {
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(flow).Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(reconCtx.Flow, flowFinalizerConst)).To(BeTrue())
+
+			persisted := &kubecloudscalerv1alpha3.Flow{}
+			Expect(reconCtx.Client.Get(reconCtx.Ctx, reconCtx.Request.NamespacedName, persisted)).To(Succeed())
+			Expect(controllerutil.ContainsFinalizer(persisted, flowFinalizerConst)).To(BeTrue())
+		})
+	})
+
+	Context("When Patch fails while adding the finalizer", func() {
+		It("returns a RecoverableError and sets RequeueAfter", func() {
+			reconCtx.Client = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(flow).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						return fmt.Errorf("persistent patch failure")
+					},
+				}).
+				Build()
+
+			err := handler.Execute(reconCtx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(shared.IsRecoverableError(err)).To(BeTrue())
+			Expect(reconCtx.RequeueAfter).To(BeNumerically(">", 0))
+		})
+	})
+
+	Context("When the flow is being deleted with a finalizer", func() {
+		It("removes the finalizer via Patch and stops the chain", func() {
+			controllerutil.AddFinalizer(flow, flowFinalizerConst)
+			now := metav1.Now()
+			flow.SetDeletionTimestamp(&now)
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).WithObjects(flow).Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.SkipRemaining).To(BeTrue())
+			Expect(controllerutil.ContainsFinalizer(reconCtx.Flow, flowFinalizerConst)).To(BeFalse())
+		})
+	})
+
+	Context("When the flow is being deleted without a finalizer", func() {
+		It("short-circuits the chain without error", func() {
+			now := metav1.Now()
+			flow.SetDeletionTimestamp(&now)
+			// Note: fake client refuses to create objects with DeletionTimestamp and no finalizers.
+			// Use an empty store; the finalizer handler only reads ctx.Flow in-memory here.
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.SkipRemaining).To(BeTrue())
+		})
+	})
+})

--- a/internal/controller/flow/service/handlers/finalizer_handler_test.go
+++ b/internal/controller/flow/service/handlers/finalizer_handler_test.go
@@ -23,8 +23,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/rs/zerolog"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -120,6 +122,105 @@ var _ = Describe("FinalizerHandler", func() {
 			flow.SetDeletionTimestamp(&now)
 			// Note: fake client refuses to create objects with DeletionTimestamp and no finalizers.
 			// Use an empty store; the finalizer handler only reads ctx.Flow in-memory here.
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.SkipRemaining).To(BeTrue())
+		})
+	})
+
+	Context("Retry-on-conflict when adding the finalizer", func() {
+		It("retries once on a 409 and succeeds on the second Patch", func() {
+			gvr := schema.GroupResource{Group: "kubecloudscaler.cloud", Resource: "flows"}
+			var patchCalls int
+			reconCtx.Client = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(flow).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCalls++
+						if patchCalls == 1 {
+							return apierrors.NewConflict(gvr, obj.GetName(), fmt.Errorf("conflict"))
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(patchCalls).To(Equal(2))
+			Expect(controllerutil.ContainsFinalizer(reconCtx.Flow, flowFinalizerConst)).To(BeTrue())
+		})
+	})
+
+	Context("Retry-on-conflict when removing the finalizer", func() {
+		It("retries once on a 409 and succeeds on the second Patch", func() {
+			controllerutil.AddFinalizer(flow, flowFinalizerConst)
+			now := metav1.Now()
+			flow.SetDeletionTimestamp(&now)
+			gvr := schema.GroupResource{Group: "kubecloudscaler.cloud", Resource: "flows"}
+			var patchCalls int
+			reconCtx.Client = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(flow).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(ctx context.Context, c client.WithWatch, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						patchCalls++
+						if patchCalls == 1 {
+							return apierrors.NewConflict(gvr, obj.GetName(), fmt.Errorf("conflict"))
+						}
+						return c.Patch(ctx, obj, patch, opts...)
+					},
+				}).
+				Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(patchCalls).To(Equal(2))
+			Expect(reconCtx.SkipRemaining).To(BeTrue())
+		})
+	})
+
+	Context("When Patch fails while removing the finalizer", func() {
+		It("returns a RecoverableError and sets RequeueAfter", func() {
+			controllerutil.AddFinalizer(flow, flowFinalizerConst)
+			now := metav1.Now()
+			flow.SetDeletionTimestamp(&now)
+			reconCtx.Client = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(flow).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+						return fmt.Errorf("persistent patch failure")
+					},
+				}).
+				Build()
+
+			err := handler.Execute(reconCtx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(shared.IsRecoverableError(err)).To(BeTrue())
+			Expect(reconCtx.RequeueAfter).To(BeNumerically(">", 0))
+			Expect(reconCtx.SkipRemaining).To(BeFalse())
+		})
+	})
+
+	Context("When Get returns NotFound while adding the finalizer", func() {
+		It("short-circuits without error (flow was deleted between Fetch and Patch)", func() {
+			// Fake client with no flow stored → Get returns NotFound.
+			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+			Expect(handler.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.SkipRemaining).To(BeTrue())
+			Expect(reconCtx.RequeueAfter).To(BeZero())
+		})
+	})
+
+	Context("When Get returns NotFound while removing the finalizer", func() {
+		It("short-circuits without error (cleanup already complete)", func() {
+			controllerutil.AddFinalizer(flow, flowFinalizerConst)
+			now := metav1.Now()
+			flow.SetDeletionTimestamp(&now)
+			// Object on ctx.Flow but absent from the API server — simulates already-deleted state.
 			reconCtx.Client = fake.NewClientBuilder().WithScheme(scheme).Build()
 
 			Expect(handler.Execute(reconCtx)).To(Succeed())

--- a/internal/controller/flow/service/handlers/handlers_suite_test.go
+++ b/internal/controller/flow/service/handlers/handlers_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestFlowHandlers(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Flow Handlers Suite")
+}

--- a/internal/controller/flow/service/handlers/processing_handler.go
+++ b/internal/controller/flow/service/handlers/processing_handler.go
@@ -41,7 +41,7 @@ func NewProcessingHandler(processor service.FlowProcessor) service.Handler {
 
 func (h *ProcessingHandler) Execute(ctx *service.FlowReconciliationContext) error {
 	if err := h.processor.ProcessFlow(ctx.Ctx, ctx.Flow); err != nil {
-		reason := "ProcessingFailed"
+		reason := service.ReasonProcessingFailed
 		if v, ok := service.AsValidationError(err); ok {
 			reason = v.Reason
 		}
@@ -49,7 +49,7 @@ func (h *ProcessingHandler) Execute(ctx *service.FlowReconciliationContext) erro
 		ctx.Condition = &metav1.Condition{
 			Type:    "Processed",
 			Status:  metav1.ConditionFalse,
-			Reason:  reason,
+			Reason:  string(reason),
 			Message: err.Error(),
 		}
 	} else {

--- a/internal/controller/flow/service/handlers/processing_handler.go
+++ b/internal/controller/flow/service/handlers/processing_handler.go
@@ -17,14 +17,18 @@ limitations under the License.
 package handlers
 
 import (
-	"fmt"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
-	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
 )
 
 // ProcessingHandler delegates flow processing to the FlowProcessor service.
 // It validates the flow, maps resources, and creates K8s/GCP child resources.
+//
+// On processing error it populates ctx.Condition (Status=False, Reason classified) and
+// ctx.ProcessingError, then returns nil so StatusHandler still runs and persists the
+// failure condition. The controller inspects ctx.ProcessingError after the chain and
+// classifies it as CriticalError (ValidationError) or RecoverableError (transient).
 type ProcessingHandler struct {
 	next      service.Handler
 	processor service.FlowProcessor
@@ -37,7 +41,24 @@ func NewProcessingHandler(processor service.FlowProcessor) service.Handler {
 
 func (h *ProcessingHandler) Execute(ctx *service.FlowReconciliationContext) error {
 	if err := h.processor.ProcessFlow(ctx.Ctx, ctx.Flow); err != nil {
-		return shared.NewRecoverableError(fmt.Errorf("process flow: %w", err))
+		reason := "ProcessingFailed"
+		if v, ok := service.AsValidationError(err); ok {
+			reason = v.Reason
+		}
+		ctx.ProcessingError = err
+		ctx.Condition = &metav1.Condition{
+			Type:    "Processed",
+			Status:  metav1.ConditionFalse,
+			Reason:  reason,
+			Message: err.Error(),
+		}
+	} else {
+		ctx.Condition = &metav1.Condition{
+			Type:    "Processed",
+			Status:  metav1.ConditionTrue,
+			Reason:  "ProcessingSucceeded",
+			Message: "Flow processed successfully",
+		}
 	}
 
 	if h.next != nil && !ctx.SkipRemaining {

--- a/internal/controller/flow/service/handlers/processing_handler_test.go
+++ b/internal/controller/flow/service/handlers/processing_handler_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service/handlers"
+)
+
+// stubProcessor returns a preset error or nil from ProcessFlow.
+type stubProcessor struct {
+	err error
+}
+
+func (s *stubProcessor) ProcessFlow(_ context.Context, _ *kubecloudscalerv1alpha3.Flow) error {
+	return s.err
+}
+
+var _ = Describe("ProcessingHandler", func() {
+	var (
+		logger   zerolog.Logger
+		reconCtx *service.FlowReconciliationContext
+	)
+
+	BeforeEach(func() {
+		logger = zerolog.Nop()
+		reconCtx = &service.FlowReconciliationContext{
+			Ctx:    context.Background(),
+			Logger: &logger,
+			Flow:   &kubecloudscalerv1alpha3.Flow{ObjectMeta: metav1.ObjectMeta{Name: "test-flow"}},
+		}
+	})
+
+	Context("When ProcessFlow succeeds", func() {
+		It("populates a success condition and leaves ProcessingError nil", func() {
+			h := handlers.NewProcessingHandler(&stubProcessor{})
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.ProcessingError).ToNot(HaveOccurred())
+			Expect(reconCtx.Condition).ToNot(BeNil())
+			Expect(reconCtx.Condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(reconCtx.Condition.Reason).To(Equal("ProcessingSucceeded"))
+		})
+	})
+
+	Context("When ProcessFlow returns a ValidationError", func() {
+		It("populates a failure condition with the validation Reason and stores ProcessingError", func() {
+			h := handlers.NewProcessingHandler(&stubProcessor{
+				err: service.NewValidationError("UnknownPeriod",
+					fmt.Errorf("period foo referenced in flows but not defined")),
+			})
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.ProcessingError).To(HaveOccurred())
+			Expect(service.IsValidationError(reconCtx.ProcessingError)).To(BeTrue())
+			Expect(reconCtx.Condition).ToNot(BeNil())
+			Expect(reconCtx.Condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(reconCtx.Condition.Reason).To(Equal("UnknownPeriod"))
+		})
+	})
+
+	Context("When ProcessFlow returns a transient error", func() {
+		It("populates a generic failure condition and stores ProcessingError", func() {
+			h := handlers.NewProcessingHandler(&stubProcessor{err: fmt.Errorf("API down")})
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(reconCtx.ProcessingError).To(HaveOccurred())
+			Expect(service.IsValidationError(reconCtx.ProcessingError)).To(BeFalse())
+			Expect(reconCtx.Condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(reconCtx.Condition.Reason).To(Equal("ProcessingFailed"))
+		})
+	})
+})

--- a/internal/controller/flow/service/handlers/processing_handler_test.go
+++ b/internal/controller/flow/service/handlers/processing_handler_test.go
@@ -39,6 +39,24 @@ func (s *stubProcessor) ProcessFlow(_ context.Context, _ *kubecloudscalerv1alpha
 	return s.err
 }
 
+// recordingHandler captures whether its Execute was invoked and a snapshot of the context
+// at the time of invocation, so tests can assert the chain continued past the previous
+// handler with the expected state.
+type recordingHandler struct {
+	called      bool
+	seenCond    *metav1.Condition
+	seenProcErr error
+}
+
+func (r *recordingHandler) Execute(ctx *service.FlowReconciliationContext) error {
+	r.called = true
+	r.seenCond = ctx.Condition
+	r.seenProcErr = ctx.ProcessingError
+	return nil
+}
+
+func (r *recordingHandler) SetNext(_ service.Handler) {}
+
 var _ = Describe("ProcessingHandler", func() {
 	var (
 		logger   zerolog.Logger
@@ -69,7 +87,7 @@ var _ = Describe("ProcessingHandler", func() {
 	Context("When ProcessFlow returns a ValidationError", func() {
 		It("populates a failure condition with the validation Reason and stores ProcessingError", func() {
 			h := handlers.NewProcessingHandler(&stubProcessor{
-				err: service.NewValidationError("UnknownPeriod",
+				err: service.NewValidationError(service.ReasonUnknownPeriod,
 					fmt.Errorf("period foo referenced in flows but not defined")),
 			})
 
@@ -78,7 +96,7 @@ var _ = Describe("ProcessingHandler", func() {
 			Expect(service.IsValidationError(reconCtx.ProcessingError)).To(BeTrue())
 			Expect(reconCtx.Condition).ToNot(BeNil())
 			Expect(reconCtx.Condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(reconCtx.Condition.Reason).To(Equal("UnknownPeriod"))
+			Expect(reconCtx.Condition.Reason).To(Equal(string(service.ReasonUnknownPeriod)))
 		})
 	})
 
@@ -90,7 +108,36 @@ var _ = Describe("ProcessingHandler", func() {
 			Expect(reconCtx.ProcessingError).To(HaveOccurred())
 			Expect(service.IsValidationError(reconCtx.ProcessingError)).To(BeFalse())
 			Expect(reconCtx.Condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(reconCtx.Condition.Reason).To(Equal("ProcessingFailed"))
+			Expect(reconCtx.Condition.Reason).To(Equal(string(service.ReasonProcessingFailed)))
+		})
+	})
+
+	Context("Chain continuation contract", func() {
+		It("invokes the next handler after a processing failure (does not short-circuit)", func() {
+			h := handlers.NewProcessingHandler(&stubProcessor{
+				err: service.NewValidationError(service.ReasonUnknownPeriod,
+					fmt.Errorf("period foo referenced in flows but not defined")),
+			})
+			next := &recordingHandler{}
+			h.SetNext(next)
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(next.called).To(BeTrue())
+			Expect(next.seenCond).ToNot(BeNil())
+			Expect(next.seenCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(next.seenProcErr).To(HaveOccurred())
+		})
+
+		It("invokes the next handler after a success", func() {
+			h := handlers.NewProcessingHandler(&stubProcessor{})
+			next := &recordingHandler{}
+			h.SetNext(next)
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(next.called).To(BeTrue())
+			Expect(next.seenCond).ToNot(BeNil())
+			Expect(next.seenCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(next.seenProcErr).ToNot(HaveOccurred())
 		})
 	})
 })

--- a/internal/controller/flow/service/handlers/status_handler.go
+++ b/internal/controller/flow/service/handlers/status_handler.go
@@ -28,8 +28,11 @@ import (
 
 var _ service.Handler = (*StatusHandler)(nil)
 
-// StatusHandler updates the Flow status using the StatusUpdater service.
-// It sets a success condition and configures requeue timing.
+// StatusHandler persists ctx.Condition on the Flow status via the StatusUpdater service,
+// falling back to a default success condition when the chain terminated before
+// ProcessingHandler populated one. Also arms the success requeue cadence — but only when
+// processing actually succeeded, so recoverable processing failures fall through to the
+// controller's error-requeue default.
 type StatusHandler struct {
 	next          service.Handler
 	statusUpdater service.StatusUpdater
@@ -59,7 +62,10 @@ func (h *StatusHandler) Execute(ctx *service.FlowReconciliationContext) error {
 		return shared.NewRecoverableError(fmt.Errorf("update flow status: %w", err))
 	}
 
-	if ctx.RequeueAfter == 0 {
+	// Only arm the success cadence when processing actually succeeded. A recoverable
+	// processing failure must fall through to the controller's error-requeue default
+	// (ReconcileErrorDuration) rather than hot-loop every ReconcileSuccessDuration.
+	if ctx.RequeueAfter == 0 && ctx.ProcessingError == nil {
 		ctx.RequeueAfter = utils.ReconcileSuccessDuration
 	}
 

--- a/internal/controller/flow/service/handlers/status_handler.go
+++ b/internal/controller/flow/service/handlers/status_handler.go
@@ -41,12 +41,21 @@ func NewStatusHandler(statusUpdater service.StatusUpdater) service.Handler {
 }
 
 func (h *StatusHandler) Execute(ctx *service.FlowReconciliationContext) error {
-	if err := h.statusUpdater.UpdateFlowStatus(ctx.Ctx, ctx.Flow, metav1.Condition{
-		Type:    "Processed",
-		Status:  metav1.ConditionTrue,
-		Reason:  "ProcessingSucceeded",
-		Message: "Flow processed successfully",
-	}); err != nil {
+	// Prefer the condition populated by ProcessingHandler so both success and failure paths
+	// are reflected on Flow.status. Fall back to a default success condition only when no
+	// handler contributed one (e.g. the chain terminated before ProcessingHandler for a
+	// reason other than deletion cleanup).
+	cond := ctx.Condition
+	if cond == nil {
+		cond = &metav1.Condition{
+			Type:    "Processed",
+			Status:  metav1.ConditionTrue,
+			Reason:  "ProcessingSucceeded",
+			Message: "Flow processed successfully",
+		}
+	}
+
+	if err := h.statusUpdater.UpdateFlowStatus(ctx.Ctx, ctx.Flow, *cond); err != nil {
 		return shared.NewRecoverableError(fmt.Errorf("update flow status: %w", err))
 	}
 

--- a/internal/controller/flow/service/handlers/status_handler_test.go
+++ b/internal/controller/flow/service/handlers/status_handler_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service/handlers"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service/testutil"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/shared"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/utils"
+)
+
+var _ = Describe("StatusHandler", func() {
+	var (
+		logger   zerolog.Logger
+		reconCtx *service.FlowReconciliationContext
+		updater  *testutil.MockStatusUpdater
+	)
+
+	BeforeEach(func() {
+		logger = zerolog.Nop()
+		updater = &testutil.MockStatusUpdater{}
+		reconCtx = &service.FlowReconciliationContext{
+			Ctx:    context.Background(),
+			Logger: &logger,
+			Flow:   &kubecloudscalerv1alpha3.Flow{ObjectMeta: metav1.ObjectMeta{Name: "test-flow"}},
+		}
+	})
+
+	Context("When ProcessingHandler populated a failure condition", func() {
+		It("persists the failure condition exactly as recorded", func() {
+			reconCtx.Condition = &metav1.Condition{
+				Type:    "Processed",
+				Status:  metav1.ConditionFalse,
+				Reason:  "UnknownPeriod",
+				Message: "period foo referenced in flows but not defined",
+			}
+			h := handlers.NewStatusHandler(updater)
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(updater.CallCount).To(Equal(1))
+			Expect(updater.LastCondition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(updater.LastCondition.Reason).To(Equal("UnknownPeriod"))
+			Expect(reconCtx.RequeueAfter).To(Equal(utils.ReconcileSuccessDuration))
+		})
+	})
+
+	Context("When no condition was populated", func() {
+		It("falls back to a default ProcessingSucceeded condition", func() {
+			h := handlers.NewStatusHandler(updater)
+
+			Expect(h.Execute(reconCtx)).To(Succeed())
+			Expect(updater.LastCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(updater.LastCondition.Reason).To(Equal("ProcessingSucceeded"))
+		})
+	})
+
+	Context("When the status update fails", func() {
+		It("returns a RecoverableError", func() {
+			updater.UpdateFlowStatusFunc = func(_ context.Context, _ *kubecloudscalerv1alpha3.Flow, _ metav1.Condition) error {
+				return fmt.Errorf("boom")
+			}
+			h := handlers.NewStatusHandler(updater)
+
+			err := h.Execute(reconCtx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(shared.IsRecoverableError(err)).To(BeTrue())
+		})
+	})
+})

--- a/internal/controller/flow/service/resource_creator.go
+++ b/internal/controller/flow/service/resource_creator.go
@@ -18,6 +18,8 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 
 	"github.com/rs/zerolog"
@@ -30,6 +32,9 @@ import (
 	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/types"
 )
+
+// maxDNS1123SubdomainLength is the upper bound on a Kubernetes resource name.
+const maxDNS1123SubdomainLength = 253
 
 // ResourceCreatorService handles creation of K8s and GCP resources
 type ResourceCreatorService struct {
@@ -63,7 +68,7 @@ func (c *ResourceCreatorService) CreateK8sResource(
 
 	k8sObj := &kubecloudscalerv1alpha3.K8s{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("flow-%s-%s", flow.Name, resourceName),
+			Name: childResourceName(flow.Name, resourceName),
 			Labels: map[string]string{
 				"flow":     flow.Name,
 				"resource": resourceName,
@@ -105,7 +110,7 @@ func (c *ResourceCreatorService) CreateGcpResource(
 
 	gcpObj := &kubecloudscalerv1alpha3.Gcp{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: fmt.Sprintf("flow-%s-%s", flow.Name, resourceName),
+			Name: childResourceName(flow.Name, resourceName),
 			Labels: map[string]string{
 				"flow":     flow.Name,
 				"resource": resourceName,
@@ -155,6 +160,24 @@ func (c *ResourceCreatorService) buildPeriods(periodsWithDelay []types.PeriodWit
 		allPeriods = append(allPeriods, curPeriod)
 	}
 	return allPeriods
+}
+
+// childResourceName builds the name of a child K8s/Gcp CR created for a given flow+resource.
+// Under the CRD validation both inputs are DNS-1123 labels ≤ 63 chars, so the naive
+// "flow-<flow>-<resource>" is well-formed and ≤ 132 chars. As a defensive guard against
+// future relaxation or conversion from older API versions (where no MaxLength existed), if
+// the combined name exceeds maxDNS1123SubdomainLength it is truncated and disambiguated
+// with a short SHA-256 suffix of the raw inputs so the child name stays both valid and
+// deterministically tied to its origin.
+func childResourceName(flowName, resourceName string) string {
+	name := fmt.Sprintf("flow-%s-%s", flowName, resourceName)
+	if len(name) <= maxDNS1123SubdomainLength {
+		return name
+	}
+	sum := sha256.Sum256([]byte(flowName + "\x00" + resourceName))
+	suffix := "-" + hex.EncodeToString(sum[:5]) // 10 hex chars
+	keep := maxDNS1123SubdomainLength - len(suffix)
+	return name[:keep] + suffix
 }
 
 // createOrUpdateResource creates or updates a resource using controllerutil.CreateOrUpdate

--- a/internal/controller/flow/service/resource_creator_name_test.go
+++ b/internal/controller/flow/service/resource_creator_name_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("childResourceName", func() {
+	It("returns the plain flow-<flow>-<resource> form for short names", func() {
+		Expect(childResourceName("my-flow", "api")).To(Equal("flow-my-flow-api"))
+	})
+
+	It("stays within DNS-1123 subdomain max length (253)", func() {
+		long := strings.Repeat("a", 200)
+		name := childResourceName(long, long)
+		Expect(len(name)).To(BeNumerically("<=", maxDNS1123SubdomainLength))
+	})
+
+	It("disambiguates oversize names with a deterministic hash suffix", func() {
+		long := strings.Repeat("a", 200)
+		a := childResourceName(long, long+"-x")
+		b := childResourceName(long+"-y", long)
+		Expect(a).ToNot(Equal(b))
+
+		// Stable across calls
+		Expect(childResourceName(long, long+"-x")).To(Equal(a))
+	})
+})

--- a/internal/controller/flow/service/resource_creator_periods_test.go
+++ b/internal/controller/flow/service/resource_creator_periods_test.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/kubecloudscaler/kubecloudscaler/api/common"
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	flowtypes "github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/types"
+)
+
+var _ = Describe("ResourceCreatorService.buildPeriods", func() {
+	var svc *ResourceCreatorService
+
+	BeforeEach(func() {
+		logger := zerolog.Nop()
+		svc = NewResourceCreatorService(nil, nil, &logger)
+	})
+
+	It("rewrites recurring Start/End with the delayed times in HH:MM format", func() {
+		base := common.ScalerPeriod{
+			Name: "biz",
+			Type: common.PeriodTypeUp,
+			Time: common.TimePeriod{Recurring: &common.RecurringPeriod{
+				StartTime: "09:00", EndTime: "17:00",
+				Days: []common.DayOfWeek{common.DayAll},
+			}},
+		}
+		delayed := flowtypes.PeriodWithDelay{
+			Period:    base,
+			StartTime: time.Date(0, 1, 1, 10, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(0, 1, 1, 16, 45, 0, 0, time.UTC),
+		}
+
+		out := svc.buildPeriods([]flowtypes.PeriodWithDelay{delayed})
+
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Time.Recurring).ToNot(BeIdenticalTo(base.Time.Recurring)) // defensive copy
+		Expect(out[0].Time.Recurring.StartTime).To(Equal("10:00"))
+		Expect(out[0].Time.Recurring.EndTime).To(Equal("16:45"))
+		// Source is not mutated
+		Expect(base.Time.Recurring.StartTime).To(Equal("09:00"))
+		Expect(base.Time.Recurring.EndTime).To(Equal("17:00"))
+	})
+
+	It("rewrites fixed Start/End with the delayed times in full datetime format", func() {
+		base := common.ScalerPeriod{
+			Name: "one-off",
+			Type: common.PeriodTypeUp,
+			Time: common.TimePeriod{Fixed: &common.FixedPeriod{
+				StartTime: "2026-01-15 09:00:00",
+				EndTime:   "2026-01-15 17:00:00",
+			}},
+		}
+		delayed := flowtypes.PeriodWithDelay{
+			Period:    base,
+			StartTime: time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(2026, 1, 15, 16, 45, 0, 0, time.UTC),
+		}
+
+		out := svc.buildPeriods([]flowtypes.PeriodWithDelay{delayed})
+
+		Expect(out).To(HaveLen(1))
+		Expect(out[0].Time.Fixed.StartTime).To(Equal("2026-01-15 10:00:00"))
+		Expect(out[0].Time.Fixed.EndTime).To(Equal("2026-01-15 16:45:00"))
+		Expect(base.Time.Fixed.StartTime).To(Equal("2026-01-15 09:00:00"))
+	})
+
+	It("returns an empty slice (not nil) when given no periods", func() {
+		out := svc.buildPeriods(nil)
+		Expect(out).ToNot(BeNil())
+		Expect(out).To(BeEmpty())
+	})
+})
+
+var _ = Describe("ResourceCreatorService.CreateK8sResource and CreateGcpResource", func() {
+	var (
+		scheme *runtime.Scheme
+		svc    *ResourceCreatorService
+		flow   *kubecloudscalerv1alpha3.Flow
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(kubecloudscalerv1alpha3.AddToScheme(scheme)).To(Succeed())
+		// Flow / K8s / Gcp are all cluster-scoped — no Namespace on the Flow.
+		flow = &kubecloudscalerv1alpha3.Flow{
+			ObjectMeta: metav1.ObjectMeta{Name: "demo-flow", UID: "flow-uid"},
+		}
+	})
+
+	newSvcWithFlow := func() *ResourceCreatorService {
+		logger := zerolog.Nop()
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(flow).Build()
+		return NewResourceCreatorService(c, scheme, &logger)
+	}
+
+	It("creates a K8s child CR with labels, owner reference, and rewritten periods", func() {
+		svc = newSvcWithFlow()
+		base := common.ScalerPeriod{
+			Name: "biz",
+			Type: common.PeriodTypeUp,
+			Time: common.TimePeriod{Recurring: &common.RecurringPeriod{
+				StartTime: "09:00", EndTime: "17:00",
+				Days: []common.DayOfWeek{common.DayAll},
+			}},
+		}
+		periods := []flowtypes.PeriodWithDelay{{
+			Period:    base,
+			StartTime: time.Date(0, 1, 1, 10, 0, 0, 0, time.UTC),
+			EndTime:   time.Date(0, 1, 1, 16, 0, 0, 0, time.UTC),
+		}}
+		spec := kubecloudscalerv1alpha3.K8sResource{
+			Name: "api",
+			Resources: common.Resources{
+				Names: []string{"api-deploy"},
+			},
+		}
+
+		err := svc.CreateK8sResource(context.Background(), flow, "api", spec, periods)
+		Expect(err).ToNot(HaveOccurred())
+
+		var got kubecloudscalerv1alpha3.K8s
+		Expect(svc.client.Get(context.Background(), types.NamespacedName{Name: "flow-demo-flow-api"}, &got)).To(Succeed())
+		Expect(got.Labels).To(HaveKeyWithValue("flow", "demo-flow"))
+		Expect(got.Labels).To(HaveKeyWithValue("resource", "api"))
+		Expect(got.OwnerReferences).To(HaveLen(1))
+		Expect(got.OwnerReferences[0].UID).To(Equal(flow.UID))
+		Expect(*got.OwnerReferences[0].Controller).To(BeTrue())
+		Expect(got.Spec.Resources.Names).To(ConsistOf("api-deploy"))
+		Expect(got.Spec.Periods).To(HaveLen(1))
+		Expect(got.Spec.Periods[0].Time.Recurring.StartTime).To(Equal("10:00"))
+		Expect(got.Spec.Periods[0].Time.Recurring.EndTime).To(Equal("16:00"))
+	})
+
+	It("preserves existing labels/annotations and overwrites Spec on update", func() {
+		svc = newSvcWithFlow()
+		spec := kubecloudscalerv1alpha3.K8sResource{Name: "api"}
+
+		Expect(svc.CreateK8sResource(context.Background(), flow, "api", spec, nil)).To(Succeed())
+
+		// Simulate an external actor adding a label and annotation between reconciles.
+		var existing kubecloudscalerv1alpha3.K8s
+		Expect(svc.client.Get(context.Background(), types.NamespacedName{Name: "flow-demo-flow-api"}, &existing)).To(Succeed())
+		if existing.Labels == nil {
+			existing.Labels = map[string]string{}
+		}
+		if existing.Annotations == nil {
+			existing.Annotations = map[string]string{}
+		}
+		existing.Labels["external"] = "kept"
+		existing.Annotations["external"] = "kept"
+		Expect(svc.client.Update(context.Background(), &existing)).To(Succeed())
+
+		// Second call with a new Spec.
+		spec.Resources.Names = []string{"api-v2"}
+		Expect(svc.CreateK8sResource(context.Background(), flow, "api", spec, nil)).To(Succeed())
+
+		var got kubecloudscalerv1alpha3.K8s
+		Expect(svc.client.Get(context.Background(), types.NamespacedName{Name: "flow-demo-flow-api"}, &got)).To(Succeed())
+		Expect(got.Labels).To(HaveKeyWithValue("external", "kept"))
+		Expect(got.Labels).To(HaveKeyWithValue("flow", "demo-flow"))
+		Expect(got.Annotations).To(HaveKeyWithValue("external", "kept"))
+		Expect(got.Spec.Resources.Names).To(ConsistOf("api-v2"))
+	})
+
+	It("creates a GCP child CR with labels, owner reference, and matching spec", func() {
+		svc = newSvcWithFlow()
+		spec := kubecloudscalerv1alpha3.GcpResource{
+			Name: "vm",
+			Resources: common.Resources{
+				Names: []string{"some-vm"},
+			},
+		}
+
+		Expect(svc.CreateGcpResource(context.Background(), flow, "vm", spec, nil)).To(Succeed())
+
+		var got kubecloudscalerv1alpha3.Gcp
+		Expect(svc.client.Get(context.Background(), types.NamespacedName{Name: "flow-demo-flow-vm"}, &got)).To(Succeed())
+		Expect(got.Labels).To(HaveKeyWithValue("flow", "demo-flow"))
+		Expect(got.Labels).To(HaveKeyWithValue("resource", "vm"))
+		Expect(got.OwnerReferences).To(HaveLen(1))
+		Expect(got.Spec.Resources.Names).To(ConsistOf("some-vm"))
+	})
+})

--- a/internal/controller/flow/service/resource_mapper.go
+++ b/internal/controller/flow/service/resource_mapper.go
@@ -127,7 +127,7 @@ func (m *ResourceMapperService) determineResourceType(
 	gcpResource *kubecloudscalerv1alpha3.GcpResource,
 ) (string, *kubecloudscalerv1alpha3.K8sResource, *kubecloudscalerv1alpha3.GcpResource, error) {
 	if k8sResource != nil && gcpResource != nil {
-		return "", nil, nil, NewValidationError("AmbiguousResource",
+		return "", nil, nil, NewValidationError(ReasonAmbiguousResource,
 			fmt.Errorf("resource %s is defined in both K8s and GCP resources", resourceName))
 	}
 
@@ -139,7 +139,7 @@ func (m *ResourceMapperService) determineResourceType(
 		return "gcp", nil, gcpResource, nil
 	}
 
-	return "", nil, nil, NewValidationError("UnknownResource",
+	return "", nil, nil, NewValidationError(ReasonUnknownResource,
 		fmt.Errorf("resource %s referenced in flows but not defined in resources", resourceName))
 }
 
@@ -160,7 +160,7 @@ func (m *ResourceMapperService) findAssociatedPeriods(
 
 			key := flowItem.PeriodName + "/" + resource.Name
 			if seen[key] {
-				return nil, NewValidationError("DuplicateResourceInPeriod", fmt.Errorf(
+				return nil, NewValidationError(ReasonDuplicateResourceInPeriod, fmt.Errorf(
 					"resource %s appears more than once for period %s in flows",
 					resource.Name, flowItem.PeriodName,
 				))
@@ -169,7 +169,7 @@ func (m *ResourceMapperService) findAssociatedPeriods(
 
 			period, exists := periodsMap[flowItem.PeriodName]
 			if !exists {
-				return nil, NewValidationError("UnknownPeriod",
+				return nil, NewValidationError(ReasonUnknownPeriod,
 					fmt.Errorf("period %s referenced in flows but not defined", flowItem.PeriodName))
 			}
 
@@ -192,13 +192,13 @@ func (m *ResourceMapperService) createPeriodWithDelay(
 ) (types.PeriodWithDelay, error) {
 	startTimeDelay, err := m.parseDelay(resource.StartTimeDelay)
 	if err != nil {
-		return types.PeriodWithDelay{}, NewValidationError("InvalidDelayFormat",
+		return types.PeriodWithDelay{}, NewValidationError(ReasonInvalidDelayFormat,
 			fmt.Errorf("invalid start time delay format for resource %s: %w", resource.Name, err))
 	}
 
 	endTimeDelay, err := m.parseDelay(resource.EndTimeDelay)
 	if err != nil {
-		return types.PeriodWithDelay{}, NewValidationError("InvalidDelayFormat",
+		return types.PeriodWithDelay{}, NewValidationError(ReasonInvalidDelayFormat,
 			fmt.Errorf("invalid end time delay format for resource %s: %w", resource.Name, err))
 	}
 

--- a/internal/controller/flow/service/resource_mapper.go
+++ b/internal/controller/flow/service/resource_mapper.go
@@ -127,7 +127,8 @@ func (m *ResourceMapperService) determineResourceType(
 	gcpResource *kubecloudscalerv1alpha3.GcpResource,
 ) (string, *kubecloudscalerv1alpha3.K8sResource, *kubecloudscalerv1alpha3.GcpResource, error) {
 	if k8sResource != nil && gcpResource != nil {
-		return "", nil, nil, fmt.Errorf("resource %s is defined in both K8s and GCP resources", resourceName)
+		return "", nil, nil, NewValidationError("AmbiguousResource",
+			fmt.Errorf("resource %s is defined in both K8s and GCP resources", resourceName))
 	}
 
 	if k8sResource != nil {
@@ -138,7 +139,8 @@ func (m *ResourceMapperService) determineResourceType(
 		return "gcp", nil, gcpResource, nil
 	}
 
-	return "", nil, nil, fmt.Errorf("resource %s referenced in flows but not defined in resources", resourceName)
+	return "", nil, nil, NewValidationError("UnknownResource",
+		fmt.Errorf("resource %s referenced in flows but not defined in resources", resourceName))
 }
 
 // findAssociatedPeriods finds all periods associated with a resource
@@ -158,16 +160,17 @@ func (m *ResourceMapperService) findAssociatedPeriods(
 
 			key := flowItem.PeriodName + "/" + resource.Name
 			if seen[key] {
-				return nil, fmt.Errorf(
+				return nil, NewValidationError("DuplicateResourceInPeriod", fmt.Errorf(
 					"resource %s appears more than once for period %s in flows",
 					resource.Name, flowItem.PeriodName,
-				)
+				))
 			}
 			seen[key] = true
 
 			period, exists := periodsMap[flowItem.PeriodName]
 			if !exists {
-				return nil, fmt.Errorf("period %s referenced in flows but not defined", flowItem.PeriodName)
+				return nil, NewValidationError("UnknownPeriod",
+					fmt.Errorf("period %s referenced in flows but not defined", flowItem.PeriodName))
 			}
 
 			periodWithDelay, err := m.createPeriodWithDelay(&period, &resource)
@@ -189,12 +192,14 @@ func (m *ResourceMapperService) createPeriodWithDelay(
 ) (types.PeriodWithDelay, error) {
 	startTimeDelay, err := m.parseDelay(resource.StartTimeDelay)
 	if err != nil {
-		return types.PeriodWithDelay{}, fmt.Errorf("invalid start time delay format for resource %s: %w", resource.Name, err)
+		return types.PeriodWithDelay{}, NewValidationError("InvalidDelayFormat",
+			fmt.Errorf("invalid start time delay format for resource %s: %w", resource.Name, err))
 	}
 
 	endTimeDelay, err := m.parseDelay(resource.EndTimeDelay)
 	if err != nil {
-		return types.PeriodWithDelay{}, fmt.Errorf("invalid end time delay format for resource %s: %w", resource.Name, err)
+		return types.PeriodWithDelay{}, NewValidationError("InvalidDelayFormat",
+			fmt.Errorf("invalid end time delay format for resource %s: %w", resource.Name, err))
 	}
 
 	startTime, err := m.timeCalculator.CalculatePeriodStartTime(period, startTimeDelay)

--- a/internal/controller/flow/service/resource_mapper_test.go
+++ b/internal/controller/flow/service/resource_mapper_test.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package service_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog"
+
+	"github.com/kubecloudscaler/kubecloudscaler/api/common"
+	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
+	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/service"
+)
+
+var _ = Describe("ResourceMapperService.CreateResourceMappings", func() {
+	var (
+		logger zerolog.Logger
+		svc    service.ResourceMapper
+	)
+
+	BeforeEach(func() {
+		logger = zerolog.Nop()
+		tc := service.NewTimeCalculatorService(&logger)
+		svc = service.NewResourceMapperService(tc, &logger)
+	})
+
+	basePeriod := common.ScalerPeriod{
+		Name: "biz",
+		Type: common.PeriodTypeUp,
+		Time: common.TimePeriod{Recurring: &common.RecurringPeriod{
+			StartTime: "09:00", EndTime: "17:00",
+			Days: []common.DayOfWeek{common.DayAll},
+		}},
+	}
+
+	It("returns a ValidationError when a resource is declared in both K8s and GCP", func() {
+		flow := &kubecloudscalerv1alpha3.Flow{
+			Spec: kubecloudscalerv1alpha3.FlowSpec{
+				Periods: []common.ScalerPeriod{basePeriod},
+				Resources: kubecloudscalerv1alpha3.Resources{
+					K8s: []kubecloudscalerv1alpha3.K8sResource{{Name: "api"}},
+					Gcp: []kubecloudscalerv1alpha3.GcpResource{{Name: "api"}},
+				},
+				Flows: []kubecloudscalerv1alpha3.Flows{
+					{PeriodName: "biz", Resources: []kubecloudscalerv1alpha3.FlowResource{{Name: "api"}}},
+				},
+			},
+		}
+
+		_, err := svc.CreateResourceMappings(flow, map[string]bool{"api": true})
+
+		Expect(err).To(HaveOccurred())
+		v, ok := service.AsValidationError(err)
+		Expect(ok).To(BeTrue())
+		Expect(v.Reason).To(Equal("AmbiguousResource"))
+	})
+
+	It("returns a ValidationError when a resource is referenced but not defined", func() {
+		flow := &kubecloudscalerv1alpha3.Flow{
+			Spec: kubecloudscalerv1alpha3.FlowSpec{
+				Periods: []common.ScalerPeriod{basePeriod},
+				Flows: []kubecloudscalerv1alpha3.Flows{
+					{PeriodName: "biz", Resources: []kubecloudscalerv1alpha3.FlowResource{{Name: "ghost"}}},
+				},
+			},
+		}
+
+		_, err := svc.CreateResourceMappings(flow, map[string]bool{"ghost": true})
+
+		Expect(err).To(HaveOccurred())
+		v, ok := service.AsValidationError(err)
+		Expect(ok).To(BeTrue())
+		Expect(v.Reason).To(Equal("UnknownResource"))
+	})
+
+	It("returns a ValidationError when the same resource appears twice in a period", func() {
+		flow := &kubecloudscalerv1alpha3.Flow{
+			Spec: kubecloudscalerv1alpha3.FlowSpec{
+				Periods: []common.ScalerPeriod{basePeriod},
+				Resources: kubecloudscalerv1alpha3.Resources{
+					K8s: []kubecloudscalerv1alpha3.K8sResource{{Name: "api"}},
+				},
+				Flows: []kubecloudscalerv1alpha3.Flows{
+					{
+						PeriodName: "biz",
+						Resources: []kubecloudscalerv1alpha3.FlowResource{
+							{Name: "api", StartTimeDelay: "0m"},
+							{Name: "api", StartTimeDelay: "1m"},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := svc.CreateResourceMappings(flow, map[string]bool{"api": true})
+
+		Expect(err).To(HaveOccurred())
+		v, ok := service.AsValidationError(err)
+		Expect(ok).To(BeTrue())
+		Expect(v.Reason).To(Equal("DuplicateResourceInPeriod"))
+	})
+
+	It("produces a valid K8s mapping with associated periods", func() {
+		flow := &kubecloudscalerv1alpha3.Flow{
+			Spec: kubecloudscalerv1alpha3.FlowSpec{
+				Periods: []common.ScalerPeriod{basePeriod},
+				Resources: kubecloudscalerv1alpha3.Resources{
+					K8s: []kubecloudscalerv1alpha3.K8sResource{{Name: "api"}},
+				},
+				Flows: []kubecloudscalerv1alpha3.Flows{
+					{PeriodName: "biz", Resources: []kubecloudscalerv1alpha3.FlowResource{{Name: "api"}}},
+				},
+			},
+		}
+
+		mapping, err := svc.CreateResourceMappings(flow, map[string]bool{"api": true})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(mapping).To(HaveKey("api"))
+		Expect(mapping["api"].Type).To(Equal("k8s"))
+		Expect(mapping["api"].K8sRes).ToNot(BeNil())
+		Expect(mapping["api"].GcpRes).To(BeNil())
+		Expect(mapping["api"].Periods).To(HaveLen(1))
+	})
+})

--- a/internal/controller/flow/service/resource_mapper_test.go
+++ b/internal/controller/flow/service/resource_mapper_test.go
@@ -66,7 +66,7 @@ var _ = Describe("ResourceMapperService.CreateResourceMappings", func() {
 		Expect(err).To(HaveOccurred())
 		v, ok := service.AsValidationError(err)
 		Expect(ok).To(BeTrue())
-		Expect(v.Reason).To(Equal("AmbiguousResource"))
+		Expect(v.Reason).To(Equal(service.ReasonAmbiguousResource))
 	})
 
 	It("returns a ValidationError when a resource is referenced but not defined", func() {
@@ -84,7 +84,7 @@ var _ = Describe("ResourceMapperService.CreateResourceMappings", func() {
 		Expect(err).To(HaveOccurred())
 		v, ok := service.AsValidationError(err)
 		Expect(ok).To(BeTrue())
-		Expect(v.Reason).To(Equal("UnknownResource"))
+		Expect(v.Reason).To(Equal(service.ReasonUnknownResource))
 	})
 
 	It("returns a ValidationError when the same resource appears twice in a period", func() {
@@ -111,7 +111,7 @@ var _ = Describe("ResourceMapperService.CreateResourceMappings", func() {
 		Expect(err).To(HaveOccurred())
 		v, ok := service.AsValidationError(err)
 		Expect(ok).To(BeTrue())
-		Expect(v.Reason).To(Equal("DuplicateResourceInPeriod"))
+		Expect(v.Reason).To(Equal(service.ReasonDuplicateResourceInPeriod))
 	})
 
 	It("produces a valid K8s mapping with associated periods", func() {

--- a/internal/controller/flow/service/testutil/mocks.go
+++ b/internal/controller/flow/service/testutil/mocks.go
@@ -25,7 +25,6 @@ import (
 	kubecloudscalerv1alpha3 "github.com/kubecloudscaler/kubecloudscaler/api/v1alpha3"
 	"github.com/kubecloudscaler/kubecloudscaler/internal/controller/flow/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // MockFlowValidator is a mock implementation of FlowValidator
@@ -108,14 +107,21 @@ func (m *MockTimeCalculator) GetPeriodDuration(period *common.ScalerPeriod) (tim
 	return time.Hour, nil
 }
 
-// MockStatusUpdater is a mock implementation of StatusUpdater
+// MockStatusUpdater is a mock implementation of the StatusUpdater interface.
+// The last condition passed to UpdateFlowStatus is kept on LastCondition so tests can
+// assert the Reason/Message recorded on the Flow even when the call succeeds.
 type MockStatusUpdater struct {
-	UpdateFlowStatusFunc func(ctx context.Context, flow *kubecloudscalerv1alpha3.Flow, condition metav1.Condition) (ctrl.Result, error)
+	UpdateFlowStatusFunc func(ctx context.Context, flow *kubecloudscalerv1alpha3.Flow, condition metav1.Condition) error
+	LastCondition        *metav1.Condition
+	CallCount            int
 }
 
-func (m *MockStatusUpdater) UpdateFlowStatus(ctx context.Context, flow *kubecloudscalerv1alpha3.Flow, condition metav1.Condition) (ctrl.Result, error) {
+func (m *MockStatusUpdater) UpdateFlowStatus(ctx context.Context, flow *kubecloudscalerv1alpha3.Flow, condition metav1.Condition) error {
+	m.CallCount++
+	copied := condition
+	m.LastCondition = &copied
 	if m.UpdateFlowStatusFunc != nil {
 		return m.UpdateFlowStatusFunc(ctx, flow, condition)
 	}
-	return ctrl.Result{}, nil
+	return nil
 }

--- a/internal/controller/flow/service/time_calculator.go
+++ b/internal/controller/flow/service/time_calculator.go
@@ -56,7 +56,10 @@ func (t *TimeCalculatorService) CalculatePeriodEndTime(period *common.ScalerPeri
 	return baseEndTime.Add(delay), nil
 }
 
-// GetPeriodDuration calculates the duration of a period
+// GetPeriodDuration calculates the duration of a period.
+// For recurring periods, an end time earlier than the start time is interpreted as a
+// cross-midnight window (e.g. 22:00 → 02:00 = 4h), matching pkg/period semantics.
+// Fixed periods require end >= start since they carry full dates.
 func (t *TimeCalculatorService) GetPeriodDuration(period *common.ScalerPeriod) (time.Duration, error) {
 	startTime, err := t.parsePeriodStartTime(period)
 	if err != nil {
@@ -69,7 +72,11 @@ func (t *TimeCalculatorService) GetPeriodDuration(period *common.ScalerPeriod) (
 	}
 
 	if endTime.Before(startTime) {
-		return 0, fmt.Errorf("end time is before start time")
+		if period.Time.Recurring != nil {
+			endTime = endTime.Add(24 * time.Hour)
+		} else {
+			return 0, fmt.Errorf("end time is before start time")
+		}
 	}
 
 	return endTime.Sub(startTime), nil

--- a/internal/controller/flow/service/time_calculator.go
+++ b/internal/controller/flow/service/time_calculator.go
@@ -56,10 +56,17 @@ func (t *TimeCalculatorService) CalculatePeriodEndTime(period *common.ScalerPeri
 	return baseEndTime.Add(delay), nil
 }
 
-// GetPeriodDuration calculates the duration of a period.
-// For recurring periods, an end time earlier than the start time is interpreted as a
-// cross-midnight window (e.g. 22:00 → 02:00 = 4h), matching pkg/period semantics.
-// Fixed periods require end >= start since they carry full dates.
+// GetPeriodDuration calculates the duration of a period. For recurring periods, an end
+// time earlier than the start time is interpreted as a cross-midnight window (e.g.
+// 22:00 → 02:00 = 4h) so downstream delay math stays meaningful; fixed periods carry full
+// datetimes and require end >= start. A period whose start equals its end is rejected as
+// ZeroPeriodDuration rather than silently returning 0 — zero-length periods never match a
+// real moment and surface as misleading InvertedWindow errors downstream.
+//
+// Note: pkg/period currently refuses cross-midnight recurring windows at activation time
+// (see pkg/period/period.go). Accepting them here for validator/mapper math only means the
+// Flow will pass structural checks but still fail activation on a 22:00→02:00 period until
+// pkg/period is aligned.
 func (t *TimeCalculatorService) GetPeriodDuration(period *common.ScalerPeriod) (time.Duration, error) {
 	startTime, err := t.parsePeriodStartTime(period)
 	if err != nil {
@@ -69,6 +76,11 @@ func (t *TimeCalculatorService) GetPeriodDuration(period *common.ScalerPeriod) (
 	endTime, err := t.parsePeriodEndTime(period)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse end time: %w", err)
+	}
+
+	if endTime.Equal(startTime) {
+		return 0, NewValidationError(ReasonZeroPeriodDuration,
+			fmt.Errorf("period has zero duration (start equals end)"))
 	}
 
 	if endTime.Before(startTime) {

--- a/internal/controller/flow/service/time_calculator_test.go
+++ b/internal/controller/flow/service/time_calculator_test.go
@@ -53,6 +53,54 @@ var _ = Describe("TimeCalculatorService", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(duration).To(Equal(8 * time.Hour))
 		})
+
+		It("should treat a recurring period that crosses midnight as spanning the next day", func() {
+			period := &common.ScalerPeriod{
+				Time: common.TimePeriod{
+					Recurring: &common.RecurringPeriod{
+						StartTime: "22:00",
+						EndTime:   "02:00",
+					},
+				},
+			}
+
+			duration, err := svc.GetPeriodDuration(period)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(4 * time.Hour))
+		})
+
+		It("should treat an exactly-midnight cross-midnight recurring period correctly", func() {
+			period := &common.ScalerPeriod{
+				Time: common.TimePeriod{
+					Recurring: &common.RecurringPeriod{
+						StartTime: "23:30",
+						EndTime:   "00:30",
+					},
+				},
+			}
+
+			duration, err := svc.GetPeriodDuration(period)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(duration).To(Equal(1 * time.Hour))
+		})
+
+		It("should still reject end-before-start for fixed periods (full datetimes)", func() {
+			period := &common.ScalerPeriod{
+				Time: common.TimePeriod{
+					Fixed: &common.FixedPeriod{
+						StartTime: "2026-04-17 10:00:00",
+						EndTime:   "2026-04-17 09:00:00",
+					},
+				},
+			}
+
+			_, err := svc.GetPeriodDuration(period)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("end time is before start time"))
+		})
 	})
 
 	Describe("CalculatePeriodStartTime", func() {


### PR DESCRIPTION
## Summary

Addresses the Critical and Important findings from the Flow controller code review. The Flow controller is an orchestrator that creates child K8s/Gcp scaler CRDs; this PR aligns its hardening with the recently-landed k8s/gcp patterns and fixes several orchestration-specific correctness bugs.

### Critical

- **Finalizer `Update` → `Patch` + `RetryOnConflict`** — finalizer add/remove now uses `MergeFromWithOptimisticLock`, scoped to `metadata.finalizers` only. Same pattern as the k8s/gcp controllers.
- **Cross-midnight periods** — `TimeCalculator.GetPeriodDuration` now treats a recurring period whose end time is earlier than its start time as spanning the next day (e.g. `22:00 → 02:00 = 4h`). Previously any recurring period crossing midnight was rejected by `ValidatePeriodTimings`, even though `pkg/period` supports it. Fixed periods still reject the case since they carry full datetimes.
- **Error classification + status reflects real outcome** — every structural user-config error (unknown period, invalid delay format, inverted window, resource defined in both K8s and Gcp, unknown resource type, duplicate resource in period) is now a typed `*ValidationError` carrying a short `Reason`. `ProcessingHandler` populates `ctx.Condition` on both success and failure paths, stores the error on `ctx.ProcessingError`, and lets the chain continue so `StatusHandler` persists the condition. The controller classifies `ValidationError` as `CriticalError` (stop hot-looping on a broken spec), other errors as `RecoverableError`. Previously every error became a `RecoverableError` and the chain aborted before `StatusHandler`, leaving `Processed=True` from a prior reconcile on a Flow that was actually failing.
- **Child CR name validation and collision safety** — `K8sResource.Name`, `GcpResource.Name`, `FlowResource.Name` now carry DNS-1123 label validation (`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`, MaxLength 63). A new `childResourceName` helper truncates and disambiguates with a SHA-256 suffix if the composed `flow-<flow>-<resource>` exceeds the 253-char subdomain limit (defensive guard against older-version conversions that predated the MaxLength constraint).

### Important

- **Handler, validator, mapper tests** — the package had tests for `FlowProcessor` only. This PR adds deterministic suites covering `FetchHandler`, `FinalizerHandler`, `ProcessingHandler`, `StatusHandler`, `FlowValidator.ValidatePeriodTimings`, `ResourceMapper.CreateResourceMappings`, and `childResourceName`. Coverage went from 0 % on these paths to 71.6 % (`service`) and 81.3 % (`handlers`).
- **Stale `MockStatusUpdater` fixed** — the old mock signature (`ctrl.Result, error`) didn't implement the current `StatusUpdater` interface and would not compile if referenced. New mock records `LastCondition` and `CallCount` so tests can assert the exact condition persisted.
- **CLAUDE.md refreshed** — the flow-controller CLAUDE.md claimed a "service-based pattern (not the handler chain)". In fact the Flow uses the same Chain of Responsibility as the k8s/gcp controllers with services injected into handlers.

## Follow-up review fixes (`750c11e`)

A second review pass surfaced two behavioural regressions and several robustness gaps. All addressed in one commit.

### Behavioural regressions (now fixed)

- **Transient processing failures no longer requeue at 1m** — `StatusHandler` previously set `RequeueAfter = ReconcileSuccessDuration` (1m) unconditionally, so a `RecoverableError` from `ProcessFlow` would hot-loop 10× more aggressively than the controller's default `ReconcileErrorDuration` (10m). The requeue is now gated on `ctx.ProcessingError == nil`.
- **StatusHandler failure no longer erases `ValidationError` classification** — when `StatusHandler` itself failed to persist a condition, the controller skipped the `ctx.ProcessingError` classification block entirely, downgrading `CriticalError` to a hot-requeuing `RecoverableError`. Classification now runs independently of the chain's returned error; both errors are joined via `errors.Join` for logging.

### Typed `ValidationReason` enum

- `ValidationError.Reason` promoted from free-form `string` to typed `ValidationReason` with 13 declared constants. Resolves the `AmbiguousResource` (code) vs `ResourceInBothK8sAndGcp` (PR description) contract mismatch and makes Reason typos compile-time errors across the 4 call sites in `flow_processor.go`, `flow_validator.go`, `resource_mapper.go`, `processing_handler.go`.

### Finalizer + validation robustness

- **NotFound on finalizer re-Get** is now a no-op (scaler was deleted between Fetch and Patch) instead of a `RecoverableError` hot-loop.
- **`ctx.Flow` refreshed** to the persisted state after a successful finalizer Patch so downstream handlers see the current `ResourceVersion`.
- **Zero-duration periods rejected** with `ReasonZeroPeriodDuration` (previously silently returned 0 and surfaced as a misleading `InvertedWindow`).
- **Duplicate period names and in-section duplicate resources** rejected with `ReasonDuplicatePeriod` / `ReasonDuplicateResource` (previously first-writer-wins with no feedback).

### New tests

- `ProcessingHandler` chain-continuation contract (regression guard for the non-short-circuit invariant).
- `FinalizerHandler` retry-on-conflict for add + remove, symmetric remove-patch-fails path, both NotFound paths.
- `FlowProcessor` reasons: `MissingK8sResource`, `MissingGcpResource`, `UnknownResourceType` now assert on `ctx.Condition.Reason`.
- `ResourceCreator` delay rewriting (`buildPeriods`) for recurring + fixed + empty; `CreateK8s/GcpResource` owner refs, labels, spec, and merge-on-update.

### Docs

- `AsValidationError` godoc corrected ("innermost" → "first"; `errors.As` stops at the outermost match).
- `StatusHandler` docstring reflects the new `ctx.Condition` flow and conditional requeue.
- `internal/controller/flow/CLAUDE.md` now notes that `pkg/period` still refuses cross-midnight recurring windows at activation time — the validator is intentionally more permissive than the runtime for duration math.
- `time_calculator.go` pkg/period parity claim corrected.

## Commits

- `2214d65` — Finalizer Patch + cross-midnight + child-name validation (Critical #1 / #2 / #5)
- `864c4c6` — `ValidationError` + status reflects outcome (Critical #7 / #8)
- `4cc43f5` — Handler / validator / mapper tests + doc refresh (Important #11)
- `750c11e` — Follow-up review fixes (requeue regression, classification erasure, typed enum, validation completeness, docs, tests)

## Test plan

- [x] `make test` — flow/service **77.3 %** (was 71.6 %), flow/service/handlers **90.4 %** (was 81.3 %)
- [x] `make lint` — zero net-new issues introduced on touched files
- [x] `go build ./...` + `go vet ./internal/controller/flow/...` clean
- [x] New deterministic suites pass: cross-midnight duration, Patch-based finalizer persistence, `ValidationError` propagation, condition recorded on both success and failure, child-name truncation/hashing, chain continuation after failure, retry-on-conflict, NotFound handling, duplicate period/resource rejection
- [x] `make generate && make manifests` run to regenerate CRDs with the new name patterns
- [ ] Verify in a real cluster: Flow with a 22:00→02:00 recurring period creates children successfully, bogus delay format surfaces `Processed=False, Reason=InvalidDelayFormat`, Flow deletion cascades to children via ownerRef, transient child-Patch failure requeues at 10m (not 1m)

## Relation to other PRs

This PR is independent of the k8s/gcp hardening PRs — disjoint packages, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
