### PR TITLE
feat(cnpg): support hibernating CloudNativePG clusters on scheduled downscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Inspired by [kube-downscaler](https://codeberg.org/hjacobs/kube-downscaler).
 
 ## Features
 
-- **Kubernetes resources**: Deployments, StatefulSets, CronJobs, HPAs, GitHub AutoScaling Runner Sets
+- **Kubernetes resources**: Deployments, StatefulSets, CronJobs, HPAs, GitHub AutoScaling Runner Sets, KEDA ScaledObjects, CloudNativePG Clusters
 - **GCP resources**: Compute Engine VM instances
 - **Flow orchestration**: coordinate scaling across multiple K8s and GCP resources with time delays
 - **Recurring and fixed periods**: schedule by day/time or specific date ranges
@@ -52,6 +52,28 @@ spec:
     types: [deployments]
   config:
     forceExcludeSystemNamespaces: true
+```
+
+#### Hibernate CloudNativePG clusters outside business hours
+
+```yaml
+apiVersion: kubecloudscaler.cloud/v1alpha3
+kind: K8s
+metadata:
+  name: db-nightly-hibernation
+spec:
+  periods:
+    - type: down
+      time:
+        recurring:
+          days: [mon, tue, wed, thu, fri]
+          startTime: "20:00"
+          endTime: "07:00"
+          timezone: "Europe/Paris"
+  resources:
+    types: [cnpg-clusters]
+  config:
+    namespaces: [staging]
 ```
 
 #### Stop GCP VMs on weekends
@@ -135,8 +157,10 @@ kubectl apply -f <scaler-resource.yaml>
 
 | Kind | Resource types |
 |------|---------------|
-| K8s | `deployments`, `statefulsets`, `cronjobs`, `hpa`, `github-ars` |
+| K8s | `deployments`, `statefulsets`, `cronjobs`, `hpa`, `github-ars`, `scaledobjects`, `cnpg-clusters` |
 | Gcp | `vm-instances` |
+
+For `cnpg-clusters`, scaling toggles the [CloudNativePG](https://cloudnative-pg.io/) `cnpg.io/hibernation` annotation: a down period hibernates the cluster (all pods are shut down while PVCs are preserved) and an up period resumes it. This makes it possible to power off non-production databases outside business hours while keeping their data intact.
 
 ### Period configuration
 

--- a/api/CLAUDE.md
+++ b/api/CLAUDE.md
@@ -3,7 +3,7 @@
 ## CRD Kinds
 
 Three CRD kinds, each with multiple API versions:
-- `K8s` - Scales Kubernetes workloads (Deployments, StatefulSets, CronJobs, HPAs, ScaledObjects)
+- `K8s` - Scales Kubernetes workloads (Deployments, StatefulSets, CronJobs, HPAs, ScaledObjects, CloudNativePG Clusters)
 - `Gcp` - Scales GCP resources (Compute Engine VM instances)
 - `Flow` - Orchestrates scaling workflows across K8s and GCP resources
 
@@ -38,7 +38,7 @@ Shared types live in `api/common/` (periods, resources, status).
 ## Resource Types
 
 Use valid `common.ResourceKind` constants (defined in `api/common/resources_type.go`):
-- K8s: `common.ResourceDeployments`, `common.ResourceStatefulSets`, `common.ResourceCronJobs`, `common.ResourceHPA`, `common.ResourceGithubARS`, `common.ResourceScaledObjects`
+- K8s: `common.ResourceDeployments`, `common.ResourceStatefulSets`, `common.ResourceCronJobs`, `common.ResourceHPA`, `common.ResourceGithubARS`, `common.ResourceScaledObjects`, `common.ResourceCNPGClusters`
 - GCP: only `common.ResourceVMInstances` (`"vm-instances"`)
 - Do NOT use arbitrary strings like `"instance"`, `"disk"`
 

--- a/api/common/resources_type.go
+++ b/api/common/resources_type.go
@@ -18,6 +18,7 @@ const (
 	ResourceGithubARS     ResourceKind = "github-ars"
 	ResourceHPA           ResourceKind = "hpa"
 	ResourceScaledObjects ResourceKind = "scaledobjects"
+	ResourceCNPGClusters  ResourceKind = "cnpg-clusters"
 	ResourceVMInstances   ResourceKind = "vm-instances"
 )
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -98,3 +98,12 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - patch
+  - update

--- a/helm/templates/manager-rbac.yaml
+++ b/helm/templates/manager-rbac.yaml
@@ -99,6 +99,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - postgresql.cnpg.io
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - patch
+  - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/CLAUDE.md
+++ b/pkg/CLAUDE.md
@@ -17,7 +17,7 @@ Period activation logic:
 Resource scaling factory:
 - `resources.NewResource(ctx, name, config, logger)` - Factory creating typed resource handlers
 - Each handler implements `SetState(ctx)` for scaling operations
-- Types: deployments, statefulsets, cronjobs, github-ars, hpa, vm-instances, scaledobjects
+- Types: deployments, statefulsets, cronjobs, github-ars, hpa, vm-instances, scaledobjects, cnpg-clusters
 
 ## Guidelines
 

--- a/pkg/k8s/resources/base/strategies.go
+++ b/pkg/k8s/resources/base/strategies.go
@@ -33,6 +33,13 @@ const (
 	KedaPausedAnnotation = "autoscaling.keda.sh/paused"
 	// KedaPausedReplicasAnnotation is the KEDA annotation to set paused replicas count.
 	KedaPausedReplicasAnnotation = "autoscaling.keda.sh/paused-replicas"
+
+	// CNPGHibernationAnnotation is the CloudNativePG annotation controlling cluster hibernation.
+	CNPGHibernationAnnotation = "cnpg.io/hibernation"
+	// CNPGHibernationOn hibernates the cluster: pods are shut down while PVCs are preserved.
+	CNPGHibernationOn = "on"
+	// CNPGHibernationOff resumes a hibernated cluster.
+	CNPGHibernationOff = "off"
 )
 
 // IntReplicasStrategy handles scaling for resources with integer replicas (Deployments, StatefulSets).
@@ -364,4 +371,89 @@ func (s *KedaPauseStrategy) restore(resource ResourceItem) (bool, error) {
 	resource.SetAnnotations(annotations)
 
 	return false, nil
+}
+
+// CNPGHibernateStrategy handles scaling for CloudNativePG Clusters.
+// Scaling is not replica-based: setting the cnpg.io/hibernation annotation to
+// "on" shuts down all cluster pods while preserving PVCs, and "off" resumes them.
+type CNPGHibernateStrategy struct {
+	kind          string
+	logger        *zerolog.Logger
+	annotationMgr utils.AnnotationManager
+}
+
+// NewCNPGHibernateStrategy creates a new CNPGHibernateStrategy.
+func NewCNPGHibernateStrategy(
+	kind string,
+	logger *zerolog.Logger,
+	annotationMgr utils.AnnotationManager,
+) *CNPGHibernateStrategy {
+	return &CNPGHibernateStrategy{
+		kind:          kind,
+		logger:        logger,
+		annotationMgr: annotationMgr,
+	}
+}
+
+// GetKind returns the resource kind.
+func (s *CNPGHibernateStrategy) GetKind() string {
+	return s.kind
+}
+
+// ApplyScaling toggles CloudNativePG hibernation based on the period type.
+// On "down" it hibernates the cluster; on "up" it resumes it. Both record the
+// original hibernation state so that restoring (going out of period) can return
+// the cluster to whatever state it was in before the scaler acted.
+func (s *CNPGHibernateStrategy) ApplyScaling(
+	_ context.Context,
+	resource ResourceItem,
+	periodType string,
+	period *periodPkg.Period,
+) (bool, error) {
+	switch periodType {
+	case periodTypeDown:
+		s.setHibernation(resource, period, CNPGHibernationOn)
+	case "up":
+		s.setHibernation(resource, period, CNPGHibernationOff)
+	default:
+		return s.restore(resource)
+	}
+
+	return false, nil
+}
+
+// setHibernation records the original hibernation state and sets the annotation
+// to the requested value.
+func (s *CNPGHibernateStrategy) setHibernation(resource ResourceItem, period *periodPkg.Period, value string) {
+	wasHibernating := isHibernating(resource.GetAnnotations())
+	annotations := s.annotationMgr.AddBoolAnnotations(resource.GetAnnotations(), period, wasHibernating)
+	annotations[CNPGHibernationAnnotation] = value
+	resource.SetAnnotations(annotations)
+}
+
+// restore returns the cluster to its original hibernation state and clears the
+// scaler bookkeeping annotations.
+func (s *CNPGHibernateStrategy) restore(resource ResourceItem) (bool, error) {
+	isAlreadyRestored, wasHibernating, annotations, err := s.annotationMgr.RestoreBoolAnnotations(resource.GetAnnotations())
+	if err != nil {
+		return false, err
+	}
+
+	if isAlreadyRestored {
+		return true, nil
+	}
+
+	if ptr.Deref(wasHibernating, false) {
+		annotations[CNPGHibernationAnnotation] = CNPGHibernationOn
+	} else {
+		delete(annotations, CNPGHibernationAnnotation)
+	}
+	resource.SetAnnotations(annotations)
+
+	return false, nil
+}
+
+// isHibernating reports whether the cluster is currently hibernated.
+func isHibernating(annotations map[string]string) bool {
+	return annotations[CNPGHibernationAnnotation] == CNPGHibernationOn
 }

--- a/pkg/k8s/resources/base/strategies_test.go
+++ b/pkg/k8s/resources/base/strategies_test.go
@@ -402,3 +402,129 @@ func TestBoolSuspendStrategy_ApplyScaling(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// CNPGHibernateStrategy
+// ---------------------------------------------------------------------------
+
+func TestCNPGHibernateStrategy_ApplyScaling(t *testing.T) {
+	annotationMgr := utils.NewAnnotationManager()
+
+	tests := []struct {
+		name            string
+		periodType      string
+		period          *periodPkg.Period
+		initAnnotations map[string]string
+		wantHibernation string // "" means the annotation must be absent
+		wantRestored    bool
+	}{
+		{
+			name:            "down: hibernates and records original state",
+			periodType:      "down",
+			period:          newTestPeriod(),
+			wantHibernation: CNPGHibernationOn,
+		},
+		{
+			name:            "up: resumes and records original state",
+			periodType:      "up",
+			period:          newTestPeriod(),
+			initAnnotations: map[string]string{CNPGHibernationAnnotation: CNPGHibernationOn},
+			wantHibernation: CNPGHibernationOff,
+		},
+		{
+			name:       "restore: was hibernated, returns to hibernated",
+			periodType: "restore",
+			period:     nil,
+			initAnnotations: map[string]string{
+				CNPGHibernationAnnotation:              CNPGHibernationOff,
+				"kubecloudscaler.cloud/original-value": "true",
+			},
+			wantHibernation: CNPGHibernationOn,
+		},
+		{
+			name:       "restore: was not hibernated, removes annotation",
+			periodType: "restore",
+			period:     nil,
+			initAnnotations: map[string]string{
+				CNPGHibernationAnnotation:              CNPGHibernationOn,
+				"kubecloudscaler.cloud/original-value": "false",
+			},
+			wantHibernation: "",
+		},
+		{
+			name:            "restore: already restored is a no-op",
+			periodType:      "restore",
+			period:          nil,
+			initAnnotations: map[string]string{},
+			wantHibernation: "",
+			wantRestored:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			annotations := make(map[string]string)
+			for k, v := range tt.initAnnotations {
+				annotations[k] = v
+			}
+
+			resource := &mockResourceItem{name: "test-cluster", namespace: "default", annotations: annotations}
+			strategy := NewCNPGHibernateStrategy("cnpgcluster", testLogger(), annotationMgr)
+
+			assert.Equal(t, "cnpgcluster", strategy.GetKind())
+
+			restored, err := strategy.ApplyScaling(context.Background(), resource, tt.periodType, tt.period)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantRestored, restored)
+
+			if tt.wantHibernation == "" {
+				assert.NotContains(t, resource.GetAnnotations(), CNPGHibernationAnnotation)
+			} else {
+				assert.Equal(t, tt.wantHibernation, resource.GetAnnotations()[CNPGHibernationAnnotation])
+			}
+		})
+	}
+}
+
+// TestCNPGHibernateStrategy_Lifecycle drives a single resource through a
+// down -> up -> restore sequence to verify the original state captured on the
+// first action survives later transitions and is honored on restore.
+func TestCNPGHibernateStrategy_Lifecycle(t *testing.T) {
+	annotationMgr := utils.NewAnnotationManager()
+	strategy := NewCNPGHibernateStrategy("cnpgcluster", testLogger(), annotationMgr)
+	ctx := context.Background()
+
+	t.Run("originally not hibernated", func(t *testing.T) {
+		resource := &mockResourceItem{name: "c", namespace: "default", annotations: map[string]string{}}
+
+		_, err := strategy.ApplyScaling(ctx, resource, "down", newTestPeriod())
+		require.NoError(t, err)
+		assert.Equal(t, CNPGHibernationOn, resource.GetAnnotations()[CNPGHibernationAnnotation])
+
+		_, err = strategy.ApplyScaling(ctx, resource, "up", newTestPeriod())
+		require.NoError(t, err)
+		assert.Equal(t, CNPGHibernationOff, resource.GetAnnotations()[CNPGHibernationAnnotation])
+
+		_, err = strategy.ApplyScaling(ctx, resource, "restore", nil)
+		require.NoError(t, err)
+		assert.NotContains(t, resource.GetAnnotations(), CNPGHibernationAnnotation)
+		assert.NotContains(t, resource.GetAnnotations(), "kubecloudscaler.cloud/original-value")
+	})
+
+	t.Run("originally hibernated", func(t *testing.T) {
+		resource := &mockResourceItem{
+			name:        "c",
+			namespace:   "default",
+			annotations: map[string]string{CNPGHibernationAnnotation: CNPGHibernationOn},
+		}
+
+		_, err := strategy.ApplyScaling(ctx, resource, "up", newTestPeriod())
+		require.NoError(t, err)
+		assert.Equal(t, CNPGHibernationOff, resource.GetAnnotations()[CNPGHibernationAnnotation])
+
+		_, err = strategy.ApplyScaling(ctx, resource, "restore", nil)
+		require.NoError(t, err)
+		assert.Equal(t, CNPGHibernationOn, resource.GetAnnotations()[CNPGHibernationAnnotation])
+		assert.NotContains(t, resource.GetAnnotations(), "kubecloudscaler.cloud/original-value")
+	})
+}

--- a/pkg/k8s/resources/cnpg/adapter.go
+++ b/pkg/k8s/resources/cnpg/adapter.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnpg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/base"
+)
+
+// clusterItem wraps a Cluster to implement the ResourceItem interface.
+type clusterItem struct {
+	*Cluster
+	unstructured *unstructured.Unstructured
+}
+
+func (c *clusterItem) GetName() string {
+	return c.Name
+}
+
+func (c *clusterItem) GetNamespace() string {
+	return c.Namespace
+}
+
+func (c *clusterItem) GetAnnotations() map[string]string {
+	return c.Annotations
+}
+
+func (c *clusterItem) SetAnnotations(annotations map[string]string) {
+	c.Annotations = annotations
+}
+
+// clusterLister implements ResourceLister for CloudNativePG Clusters.
+type clusterLister struct {
+	client dynamic.NamespaceableResourceInterface
+	logger *zerolog.Logger
+}
+
+func (l *clusterLister) List(ctx context.Context, namespace string, opts metaV1.ListOptions) ([]base.ResourceItem, error) {
+	list, err := l.client.Namespace(namespace).List(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	items := make([]base.ResourceItem, 0, len(list.Items))
+	for i := range list.Items {
+		item := &list.Items[i]
+		cluster := &Cluster{}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, cluster); err != nil {
+			if l.logger != nil {
+				l.logger.Warn().Err(err).
+					Str("namespace", namespace).
+					Str("name", item.GetName()).
+					Msg("skipping Cluster item due to conversion failure")
+			}
+			continue
+		}
+		items = append(items, &clusterItem{
+			Cluster:      cluster,
+			unstructured: item,
+		})
+	}
+
+	return items, nil
+}
+
+// clusterGetter implements ResourceGetter for CloudNativePG Clusters.
+type clusterGetter struct {
+	client dynamic.NamespaceableResourceInterface
+}
+
+func (g *clusterGetter) Get(ctx context.Context, namespace, name string, opts metaV1.GetOptions) (base.ResourceItem, error) {
+	item, err := g.client.Namespace(namespace).Get(ctx, name, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := &Cluster{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(item.Object, cluster); err != nil {
+		return nil, fmt.Errorf("error converting unstructured to Cluster: %w", err)
+	}
+
+	return &clusterItem{
+		Cluster:      cluster,
+		unstructured: item,
+	}, nil
+}
+
+// clusterUpdater implements ResourceUpdater for CloudNativePG Clusters.
+type clusterUpdater struct {
+	client dynamic.NamespaceableResourceInterface
+}
+
+func (u *clusterUpdater) Update(
+	ctx context.Context,
+	namespace string,
+	resource base.ResourceItem,
+	opts metaV1.UpdateOptions,
+) (base.ResourceItem, error) {
+	item, ok := resource.(*clusterItem)
+	if !ok {
+		return nil, base.NewTypeAssertionError("*clusterItem", resource)
+	}
+
+	// Start from a deep copy of the full live object so all Cluster fields not
+	// mirrored in the local type (spec.instances, storage, etc.) are preserved.
+	// Only the annotations we manage are patched.
+	obj := item.unstructured.DeepCopy()
+	obj.SetAnnotations(item.Cluster.GetAnnotations())
+
+	updated, err := u.client.Namespace(namespace).Update(ctx, obj, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	cluster := &Cluster{}
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(updated.Object, cluster); err != nil {
+		return nil, fmt.Errorf("error converting updated unstructured to Cluster: %w", err)
+	}
+
+	return &clusterItem{
+		Cluster:      cluster,
+		unstructured: updated,
+	}, nil
+}

--- a/pkg/k8s/resources/cnpg/adapter_test.go
+++ b/pkg/k8s/resources/cnpg/adapter_test.go
@@ -1,0 +1,151 @@
+package cnpg
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/base"
+)
+
+var testGVR = schema.GroupVersionResource{
+	Group:    "postgresql.cnpg.io",
+	Version:  "v1",
+	Resource: "clusters",
+}
+
+// liveCluster builds an unstructured Cluster carrying spec fields the scaler does
+// not manage, so the test can assert they survive an annotation-only update.
+func liveCluster(name, namespace string, annotations map[string]interface{}) *unstructured.Unstructured {
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "postgresql.cnpg.io/v1",
+			"kind":       "Cluster",
+			"metadata": map[string]interface{}{
+				"name":        name,
+				"namespace":   namespace,
+				"annotations": annotations,
+			},
+			"spec": map[string]interface{}{
+				"instances": int64(3),
+				"storage": map[string]interface{}{
+					"size": "10Gi",
+				},
+			},
+		},
+	}
+}
+
+func TestClusterUpdater_PreservesUnmanagedSpecFields(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+		scheme,
+		map[schema.GroupVersionResource]string{testGVR: "ClusterList"},
+		liveCluster("cluster-a", "test-ns", map[string]interface{}{"team": "platform"}),
+	)
+	client := dynClient.Resource(testGVR)
+
+	getter := &clusterGetter{client: client}
+	item, err := getter.Get(context.Background(), "test-ns", "cluster-a", metaV1.GetOptions{})
+	require.NoError(t, err)
+
+	// Simulate the strategy hibernating the cluster via annotations only.
+	item.SetAnnotations(map[string]string{
+		"team":                         "platform",
+		base.CNPGHibernationAnnotation: base.CNPGHibernationOn,
+	})
+
+	updater := &clusterUpdater{client: client}
+	_, err = updater.Update(context.Background(), "test-ns", item, metaV1.UpdateOptions{})
+	require.NoError(t, err)
+
+	live, err := client.Namespace("test-ns").Get(context.Background(), "cluster-a", metaV1.GetOptions{})
+	require.NoError(t, err)
+
+	annotations := live.GetAnnotations()
+	assert.Equal(t, base.CNPGHibernationOn, annotations[base.CNPGHibernationAnnotation])
+	assert.Equal(t, "platform", annotations["team"])
+
+	// The unmanaged spec must be untouched.
+	instances, found, err := unstructured.NestedInt64(live.Object, "spec", "instances")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, int64(3), instances)
+
+	size, found, err := unstructured.NestedString(live.Object, "spec", "storage", "size")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "10Gi", size)
+}
+
+func TestClusterUpdater_RejectsForeignResourceItem(t *testing.T) {
+	updater := &clusterUpdater{}
+	_, err := updater.Update(context.Background(), "test-ns", foreignItem{}, metaV1.UpdateOptions{})
+
+	require.Error(t, err)
+	var typeErr *base.TypeAssertionError
+	assert.ErrorAs(t, err, &typeErr)
+}
+
+// foreignItem is a ResourceItem that is not a *clusterItem, used to exercise the
+// updater's type-assertion guard.
+type foreignItem struct{}
+
+func (foreignItem) GetName() string                   { return "foreign" }
+func (foreignItem) GetNamespace() string              { return "test-ns" }
+func (foreignItem) GetAnnotations() map[string]string { return nil }
+func (foreignItem) SetAnnotations(map[string]string)  {}
+
+func TestCnpg_Init_WiresClientAndAnnotationManager(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+	dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
+
+	c := &Cnpg{}
+	c.init(dynClient)
+
+	assert.NotNil(t, c.Client)
+	assert.NotNil(t, c.AnnotationManager)
+}
+
+func TestCluster_DeepCopyObject(t *testing.T) {
+	var nilCluster *Cluster
+	assert.Nil(t, nilCluster.DeepCopyObject())
+
+	original := &Cluster{
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:        "cluster-a",
+			Annotations: map[string]string{base.CNPGHibernationAnnotation: base.CNPGHibernationOn},
+		},
+	}
+	copied, ok := original.DeepCopyObject().(*Cluster)
+	require.True(t, ok)
+	copied.Annotations[base.CNPGHibernationAnnotation] = base.CNPGHibernationOff
+	assert.Equal(t, base.CNPGHibernationOn, original.Annotations[base.CNPGHibernationAnnotation])
+}
+
+func TestClusterList_DeepCopyObject(t *testing.T) {
+	var nilList *ClusterList
+	assert.Nil(t, nilList.DeepCopyObject())
+
+	original := &ClusterList{
+		Items: []Cluster{
+			{ObjectMeta: metaV1.ObjectMeta{Name: "cluster-a"}},
+			{ObjectMeta: metaV1.ObjectMeta{Name: "cluster-b"}},
+		},
+	}
+	copied, ok := original.DeepCopyObject().(*ClusterList)
+	require.True(t, ok)
+	require.Len(t, copied.Items, 2)
+	copied.Items[0].Name = "mutated"
+	assert.Equal(t, "cluster-a", original.Items[0].Name)
+}

--- a/pkg/k8s/resources/cnpg/cnpg.go
+++ b/pkg/k8s/resources/cnpg/cnpg.go
@@ -1,0 +1,57 @@
+package cnpg
+
+// +kubebuilder:rbac:groups=postgresql.cnpg.io,resources=clusters,verbs=get;list;update;patch
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecloudscaler/kubecloudscaler/api/common"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/base"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/utils"
+)
+
+const (
+	clusterKind    = "cnpgcluster"
+	clusterGroup   = "postgresql.cnpg.io"
+	clusterVersion = "v1"
+)
+
+func (c *Cnpg) init(client dynamic.Interface) {
+	c.Client = client.Resource(schema.GroupVersionResource{
+		Group:    clusterGroup,
+		Version:  clusterVersion,
+		Resource: "clusters",
+	})
+	c.AnnotationManager = utils.NewAnnotationManager()
+}
+
+// SetState sets the state of CloudNativePG Cluster resources based on the current period.
+func (c *Cnpg) SetState(ctx context.Context) ([]common.ScalerStatusSuccess, []common.ScalerStatusFailed, error) {
+	// Create adapters
+	lister := &clusterLister{client: c.Client, logger: c.Logger}
+	getter := &clusterGetter{client: c.Client}
+	updater := &clusterUpdater{client: c.Client}
+
+	// Create CNPG hibernation strategy
+	strategy := base.NewCNPGHibernateStrategy(
+		clusterKind,
+		c.Logger,
+		c.AnnotationManager,
+	)
+
+	// Create processor
+	processor := base.NewProcessor(
+		lister,
+		getter,
+		updater,
+		strategy,
+		c.Resource,
+		c.Logger,
+	)
+
+	// Process resources
+	return processor.ProcessResources(ctx)
+}

--- a/pkg/k8s/resources/cnpg/cnpg_test.go
+++ b/pkg/k8s/resources/cnpg/cnpg_test.go
@@ -1,0 +1,296 @@
+package cnpg_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/testing"
+
+	"github.com/kubecloudscaler/kubecloudscaler/api/common"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/base"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/cnpg"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/utils"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/period"
+)
+
+const periodTypeRestore = "restore"
+
+var (
+	gvr = schema.GroupVersionResource{
+		Group:    "postgresql.cnpg.io",
+		Version:  "v1",
+		Resource: "clusters",
+	}
+	clusterGVK = schema.GroupVersionKind{
+		Group:   "postgresql.cnpg.io",
+		Version: "v1",
+		Kind:    "Cluster",
+	}
+)
+
+func newCluster(name, namespace string, annotations map[string]string) *cnpg.Cluster {
+	return &cnpg.Cluster{
+		TypeMeta: metaV1.TypeMeta{
+			Kind:       clusterGVK.Kind,
+			APIVersion: fmt.Sprintf("%s/%s", clusterGVK.Group, clusterGVK.Version),
+		},
+		ObjectMeta: metaV1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+}
+
+var _ = Describe("Cnpg", func() {
+	var (
+		ctx        context.Context
+		scheme     *runtime.Scheme
+		dynClient  *dynamicfake.FakeDynamicClient
+		resource   *utils.K8sResource
+		mockPeriod *period.Period
+		manager    *cnpg.Cnpg
+	)
+
+	setupManager := func(objs ...runtime.Object) {
+		dynClient = dynamicfake.NewSimpleDynamicClientWithCustomListKinds(
+			scheme,
+			map[schema.GroupVersionResource]string{
+				gvr: "ClusterList",
+			},
+			objs...,
+		)
+
+		manager = &cnpg.Cnpg{
+			Resource:          resource,
+			Logger:            &log.Logger,
+			AnnotationManager: utils.NewAnnotationManager(),
+		}
+		manager.Client = dynClient.Resource(gvr)
+	}
+
+	getCluster := func(namespace, name string) *cnpg.Cluster {
+		obj, err := dynClient.Resource(gvr).Namespace(namespace).Get(ctx, name, metaV1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		cluster := &cnpg.Cluster{}
+		Expect(runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, cluster)).To(Succeed())
+		return cluster
+	}
+
+	origValueKey := utils.AnnotationsPrefix + "/" + utils.AnnotationsOrigValue
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(cnpg.AddToScheme(scheme)).To(Succeed())
+
+		mockPeriod = &period.Period{
+			Type:      common.PeriodTypeDown,
+			IsActive:  true,
+			StartTime: time.Now(),
+			EndTime:   time.Now(),
+			Spec: &common.RecurringPeriod{
+				Days:      []common.DayOfWeek{common.DayAll},
+				StartTime: "00:00",
+				EndTime:   "23:59",
+			},
+		}
+
+		resource = &utils.K8sResource{
+			NsList:      []string{"test-ns"},
+			ListOptions: metaV1.ListOptions{},
+			Period:      mockPeriod,
+		}
+	})
+
+	Context("scaling down (hibernate)", func() {
+		It("hibernates the cluster and records the original state", func() {
+			mockPeriod.Type = common.PeriodTypeDown
+
+			setupManager(newCluster("cluster-down", "test-ns", nil))
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failed).To(BeEmpty())
+			Expect(success).To(HaveLen(1))
+			Expect(success[0].Kind).To(Equal("cnpgcluster"))
+			Expect(success[0].Name).To(Equal("cluster-down"))
+
+			updated := getCluster("test-ns", "cluster-down")
+			Expect(updated.Annotations).To(HaveKeyWithValue(base.CNPGHibernationAnnotation, base.CNPGHibernationOn))
+			Expect(updated.Annotations).To(HaveKeyWithValue(origValueKey, "false"))
+		})
+
+		It("preserves unrelated annotations when hibernating", func() {
+			mockPeriod.Type = common.PeriodTypeDown
+
+			setupManager(newCluster("cluster-keep", "test-ns", map[string]string{
+				"team": "platform",
+			}))
+
+			success, _, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(success).To(HaveLen(1))
+
+			updated := getCluster("test-ns", "cluster-keep")
+			Expect(updated.Annotations).To(HaveKeyWithValue("team", "platform"))
+			Expect(updated.Annotations).To(HaveKeyWithValue(base.CNPGHibernationAnnotation, base.CNPGHibernationOn))
+		})
+	})
+
+	Context("scaling up (resume)", func() {
+		It("resumes a hibernated cluster", func() {
+			mockPeriod.Type = common.PeriodTypeUp
+
+			setupManager(newCluster("cluster-up", "test-ns", map[string]string{
+				base.CNPGHibernationAnnotation: base.CNPGHibernationOn,
+			}))
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failed).To(BeEmpty())
+			Expect(success).To(HaveLen(1))
+
+			updated := getCluster("test-ns", "cluster-up")
+			Expect(updated.Annotations).To(HaveKeyWithValue(base.CNPGHibernationAnnotation, base.CNPGHibernationOff))
+			Expect(updated.Annotations).To(HaveKeyWithValue(origValueKey, "true"))
+		})
+	})
+
+	Context("restoring (going out of period)", func() {
+		It("restores a cluster that was hibernated before the scaler acted", func() {
+			mockPeriod.Type = periodTypeRestore
+
+			setupManager(newCluster("cluster-was-on", "test-ns", map[string]string{
+				base.CNPGHibernationAnnotation: base.CNPGHibernationOff,
+				origValueKey:                   "true",
+			}))
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failed).To(BeEmpty())
+			Expect(success).To(HaveLen(1))
+
+			updated := getCluster("test-ns", "cluster-was-on")
+			Expect(updated.Annotations).To(HaveKeyWithValue(base.CNPGHibernationAnnotation, base.CNPGHibernationOn))
+			Expect(updated.Annotations).ToNot(HaveKey(origValueKey))
+		})
+
+		It("removes the hibernation annotation for a cluster that was not hibernated before", func() {
+			mockPeriod.Type = periodTypeRestore
+
+			setupManager(newCluster("cluster-was-off", "test-ns", map[string]string{
+				base.CNPGHibernationAnnotation: base.CNPGHibernationOn,
+				origValueKey:                   "false",
+			}))
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(failed).To(BeEmpty())
+			Expect(success).To(HaveLen(1))
+
+			updated := getCluster("test-ns", "cluster-was-off")
+			Expect(updated.Annotations).ToNot(HaveKey(base.CNPGHibernationAnnotation))
+			Expect(updated.Annotations).ToNot(HaveKey(origValueKey))
+		})
+
+		It("ignores clusters that were never touched by the scaler", func() {
+			mockPeriod.Type = periodTypeRestore
+
+			setupManager(newCluster("cluster-untouched", "test-ns", nil))
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(success).To(BeEmpty())
+			Expect(failed).To(BeEmpty())
+		})
+	})
+
+	Context("error handling", func() {
+		It("returns list error", func() {
+			setupManager()
+
+			dynClient.PrependReactor("list", "clusters", func(_ testing.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("boom")
+			})
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error listing cnpgclusters"))
+			Expect(success).To(BeEmpty())
+			Expect(failed).To(BeEmpty())
+		})
+
+		It("records restore failures when the recorded state is invalid", func() {
+			mockPeriod.Type = periodTypeRestore
+
+			setupManager(newCluster("cluster-bad", "test-ns", map[string]string{
+				base.CNPGHibernationAnnotation: base.CNPGHibernationOn,
+				origValueKey:                   "not-a-bool",
+			}))
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(success).To(BeEmpty())
+			Expect(failed).To(HaveLen(1))
+			Expect(failed[0].Name).To(Equal("cluster-bad"))
+			Expect(failed[0].Reason).To(ContainSubstring("error parsing bool value"))
+		})
+
+		It("records update failures", func() {
+			setupManager(newCluster("cluster-update", "test-ns", nil))
+
+			dynClient.PrependReactor("update", "clusters", func(_ testing.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("update failure")
+			})
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(success).To(BeEmpty())
+			Expect(failed).To(HaveLen(1))
+			Expect(failed[0].Name).To(Equal("cluster-update"))
+			Expect(failed[0].Reason).To(ContainSubstring("update failure"))
+		})
+	})
+
+	Context("multi namespace management", func() {
+		It("hibernates clusters across namespaces", func() {
+			resource.NsList = []string{"ns-one", "ns-two"}
+			mockPeriod.Type = common.PeriodTypeDown
+
+			setupManager(
+				newCluster("cluster-one", "ns-one", nil),
+				newCluster("cluster-two", "ns-two", nil),
+			)
+
+			success, failed, err := manager.SetState(ctx)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(success).To(HaveLen(2))
+			Expect(failed).To(BeEmpty())
+
+			Expect(getCluster("ns-one", "cluster-one").Annotations).
+				To(HaveKeyWithValue(base.CNPGHibernationAnnotation, base.CNPGHibernationOn))
+			Expect(getCluster("ns-two", "cluster-two").Annotations).
+				To(HaveKeyWithValue(base.CNPGHibernationAnnotation, base.CNPGHibernationOn))
+		})
+	})
+})

--- a/pkg/k8s/resources/cnpg/cnpg_types.go
+++ b/pkg/k8s/resources/cnpg/cnpg_types.go
@@ -1,0 +1,66 @@
+// Package cnpg includes local CloudNativePG type shims for listers and adapters.
+//
+// +kubebuilder:object:generate=false
+// +kubebuilder:skip
+package cnpg
+
+import (
+	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// SchemeGroupVersion is the GVR for CloudNativePG Clusters.
+var SchemeGroupVersion = schema.GroupVersion{Group: "postgresql.cnpg.io", Version: "v1"}
+
+// AddToScheme registers Cluster types with the given scheme.
+func AddToScheme(s *runtime.Scheme) error {
+	s.AddKnownTypes(SchemeGroupVersion,
+		&Cluster{},
+		&ClusterList{},
+	)
+	metaV1.AddToGroupVersion(s, SchemeGroupVersion)
+	return nil
+}
+
+// ClusterList is a list of Cluster resources.
+type ClusterList struct {
+	metaV1.TypeMeta `json:",inline"`
+	metaV1.ListMeta `json:"metadata,omitempty"`
+	Items           []Cluster `json:"items"`
+}
+
+// DeepCopyObject implements runtime.Object.
+func (l *ClusterList) DeepCopyObject() runtime.Object {
+	if l == nil {
+		return nil
+	}
+	out := *l
+	if l.Items != nil {
+		out.Items = make([]Cluster, len(l.Items))
+		for i := range l.Items {
+			obj := l.Items[i].DeepCopyObject()
+			out.Items[i] = *obj.(*Cluster) //nolint:errcheck // type assertion is guaranteed safe
+		}
+	}
+	return &out
+}
+
+// Cluster mirrors the CloudNativePG Cluster CRD (postgresql.cnpg.io/v1).
+// Defined locally to avoid importing the full cloudnative-pg module. Hibernation
+// is driven entirely by the cnpg.io/hibernation annotation on metadata, so only
+// ObjectMeta is needed here; no spec fields are mirrored.
+type Cluster struct {
+	metaV1.TypeMeta   `json:",inline"`
+	metaV1.ObjectMeta `json:"metadata,omitempty"`
+}
+
+// DeepCopyObject implements runtime.Object.
+func (c *Cluster) DeepCopyObject() runtime.Object {
+	if c == nil {
+		return nil
+	}
+	out := *c
+	c.DeepCopyInto(&out.ObjectMeta)
+	return &out
+}

--- a/pkg/k8s/resources/cnpg/suite_test.go
+++ b/pkg/k8s/resources/cnpg/suite_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cnpg_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func TestCnpg(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecs(t, "CloudNativePG Clusters Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+})
+
+var _ = AfterSuite(func() {})

--- a/pkg/k8s/resources/cnpg/types.go
+++ b/pkg/k8s/resources/cnpg/types.go
@@ -1,0 +1,17 @@
+// Package cnpg provides type definitions for CloudNativePG Cluster resource management.
+package cnpg
+
+import (
+	"github.com/rs/zerolog"
+	"k8s.io/client-go/dynamic"
+
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/utils"
+)
+
+// Cnpg represents a CloudNativePG Cluster resource manager.
+type Cnpg struct {
+	Resource          *utils.K8sResource
+	Client            dynamic.NamespaceableResourceInterface
+	Logger            *zerolog.Logger
+	AnnotationManager utils.AnnotationManager
+}

--- a/pkg/k8s/resources/cnpg/utils.go
+++ b/pkg/k8s/resources/cnpg/utils.go
@@ -1,0 +1,32 @@
+// Package cnpg provides utility functions for CloudNativePG Cluster resource management.
+package cnpg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/rs/zerolog"
+
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/utils"
+)
+
+// New creates a new CloudNativePG Cluster resource manager.
+func New(ctx context.Context, config *utils.Config) (*Cnpg, error) {
+	logger := zerolog.Ctx(ctx)
+	clientAdapter := utils.NewKubernetesClientAdapter(config.Client)
+	namespaceMgr := utils.NewNamespaceManager(clientAdapter, *logger, nil)
+
+	k8sResource, err := namespaceMgr.InitConfig(ctx, config)
+	if err != nil {
+		return nil, fmt.Errorf("error initializing k8s config: %w", err)
+	}
+
+	resource := &Cnpg{
+		Resource: k8sResource,
+		Logger:   logger,
+	}
+
+	resource.init(config.DynamicClient)
+
+	return resource, nil
+}

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 
 	vminstances "github.com/kubecloudscaler/kubecloudscaler/pkg/gcp/resources/vm-instances"
+	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/cnpg"
 	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/cronjobs"
 	"github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/deployments"
 	ars "github.com/kubecloudscaler/kubecloudscaler/pkg/k8s/resources/github_autoscalingrunnersets"
@@ -34,6 +35,8 @@ func NewResource(ctx context.Context, resourceName string, config Config, logger
 		return newGitHubARSResource(ctx, config)
 	case "scaledobjects":
 		return newScaledObjectsResource(ctx, config)
+	case "cnpg-clusters":
+		return newCNPGClustersResource(ctx, config)
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrResourceNotFound, resourceName)
 	}
@@ -107,6 +110,18 @@ func newScaledObjectsResource(ctx context.Context, config Config) (Resource, err
 	resource, err := scaledobjects.New(ctx, config.K8s)
 	if err != nil {
 		return nil, fmt.Errorf("error creating scaledobjects resource: %w", err)
+	}
+	return resource, nil
+}
+
+// newCNPGClustersResource creates a new cnpg-clusters resource
+func newCNPGClustersResource(ctx context.Context, config Config) (Resource, error) {
+	if config.K8s == nil {
+		return nil, fmt.Errorf("K8s config is required for cnpg-clusters resource")
+	}
+	resource, err := cnpg.New(ctx, config.K8s)
+	if err != nil {
+		return nil, fmt.Errorf("error creating cnpg-clusters resource: %w", err)
 	}
 	return resource, nil
 }

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -51,6 +51,7 @@ func TestNewResource_K8sResourcesWithNilK8sConfig(t *testing.T) {
 		"cronjobs",
 		"github-ars",
 		"scaledobjects",
+		"cnpg-clusters",
 	}
 
 	for _, resourceName := range k8sResources {
@@ -100,6 +101,7 @@ func TestGetAvailableResources(t *testing.T) {
 		"cronjobs",
 		"github-ars",
 		"scaledobjects",
+		"cnpg-clusters",
 	}
 
 	assert.Equal(t, expected, resources)

--- a/pkg/resources/vars.go
+++ b/pkg/resources/vars.go
@@ -18,6 +18,7 @@ var availableResources = []string{
 	"cronjobs",
 	"github-ars",
 	"scaledobjects",
+	"cnpg-clusters",
 }
 
 // GetAvailableResources returns a copy of the available resource types for scaling.


### PR DESCRIPTION
## Summary

Adds a new `cnpg-clusters` Kubernetes resource type so `K8s` (and `Flow`) scalers can power [CloudNativePG](https://cloudnative-pg.io/) clusters up and down on a schedule.

Unlike replica-based kinds, a CloudNativePG `Cluster` is scaled through its `cnpg.io/hibernation` annotation:

- a **down** period sets `cnpg.io/hibernation: "on"`, which shuts down all cluster pods while preserving the PVCs (data and WAL),
- an **up** period sets it to `"off"` to resume the cluster,
- leaving the period restores the cluster to the hibernation state it had before the scaler first acted on it.

This lets non-production databases be switched off outside business hours to save compute while keeping their data intact.

## Design

The implementation mirrors the existing `scaledobjects` kind, which already scales a CRD through an annotation using the dynamic client:

- `pkg/k8s/resources/cnpg/` — new resource package (lister/getter/updater adapters over the dynamic client, plus a minimal local `Cluster` type shim so the full cloudnative-pg module does not have to be imported). The updater starts from a deep copy of the live object and only touches the annotations it manages, so unrelated spec fields are preserved.
- `pkg/k8s/resources/base/strategies.go` — new `CNPGHibernateStrategy`, following the same shape as `KedaPauseStrategy`. It records the original hibernation state via the shared annotation manager so the resource can be restored on the way out of a period.
- `pkg/resources/` and `api/common/resources_type.go` — registry, factory and `ResourceKind` constant wiring.
- RBAC for `postgresql.cnpg.io/clusters` (`get;list;patch;update`) in both the kustomize role and the Helm chart.

## Testing

- Unit tests (`pkg/k8s/resources/cnpg/`) cover hibernate, resume, both restore paths (was-hibernating and was-not), the already-restored no-op, unrelated-annotation preservation, unmanaged-spec preservation, multi-namespace handling, and list/update/parse error paths.
- `make test`, `make lint`, `make generate` and `make manifests` all pass locally.

## Notes

- The CloudNativePG `Cluster` CRD is not a dependency; only a minimal local type is used, matching how the KEDA `ScaledObject` type is handled.
- Hibernation only stops the cluster's compute; PVCs remain (and remain billed). Backups scheduled via a separate `ScheduledBackup` are not affected by this annotation and should be considered separately if they must be paused during hibernation.
